### PR TITLE
Fix read-only crash on restarting a game

### DIFF
--- a/src/Matchimals/game.js
+++ b/src/Matchimals/game.js
@@ -134,8 +134,10 @@ export function getInitialState(ctx) {
     };
   }
 
-  // Fill the game board
-  G.cells = emptyCells;
+  // Fill the game board. Copy the shared module-level array so each game gets
+  // its own cells — otherwise the first game's state freeze (Immer, in dev)
+  // makes `emptyCells` read-only and the next game throws on G.cells[center] = …
+  G.cells = [...emptyCells];
 
   // Set the initial card on the board
   const initialCard = getRandomCard(deck); // TODO: Use boardgame.io provided random function


### PR DESCRIPTION
## Problem

Starting a game, exiting to the main menu, then starting another game crashes with:

```
[TypeError: Cannot assign to read-only property]
  at WrappedBoard ...
  at PlayerProvider ...
```

## Cause

`getInitialState` in `src/Matchimals/game.js` did:

```js
G.cells = emptyCells;        // reference to the shared module-level array
G.cells[center] = initialCard; // mutates that shared array
```

`emptyCells` (`src/constants/board.js`) is a single module-level array shared for the app's whole lifetime. The first game works, but boardgame.io passes the `setup` result through Immer's `produce`, which **deep-freezes state in dev mode** — freezing the shared array in place. On the second game, `getInitialState` re-runs, reassigns the now-frozen `emptyCells`, and `G.cells[center] = initialCard` throws *Cannot assign to read-only property*.

## Fix

Copy the array so each game gets its own `cells`:

```js
G.cells = [...emptyCells];
```

The other shared imports are safe: `deck` goes through `concat`/`shuffle` (new arrays) and the card objects are only read, never mutated.

## Testing

No automated tests exist in this repo. Not yet verified at runtime (browser/simulator driver wasn't available in this environment); the fix is a one-line reference→copy change matching the established failure mode. Recommend a manual smoke test: start → exit to menu → start again, a few times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)