### PR TITLE
Add pinch-to-zoom to the board

### DIFF
--- a/src/Matchimals/index.js
+++ b/src/Matchimals/index.js
@@ -21,21 +21,27 @@ const Matchimals = ({ backToMainMenu, ctx, G, moves, ...rest }) => {
 
   const onCardDrop = useCallback(
     (measurements) => {
-      // Get the top left corner of the card in relation to the viewport
-      const cardLeft = measurements.pageX;
-      const cardTop = measurements.pageY;
+      // The dragged card stays full screen-size while the board scales, so when
+      // zoomed out the card visually covers several cells. Use the card's CENTER
+      // (not its top-left corner) as the drop point so it lands where the player
+      // aims regardless of zoom. At zoom == 1 this is equivalent to the old
+      // top-left + round, since the card is exactly one cell wide there.
+      const cardCenterLeft = measurements.pageX + measurements.width / 2;
+      const cardCenterTop = measurements.pageY + measurements.height / 2;
 
       // Get the top left corner of the viewport in relation to the entire table
       const tableLeft = tableRef.current._previousLeft;
       const tableTop = tableRef.current._previousTop;
+      const scale = tableRef.current._previousScale || 1;
 
-      // Calculate the total distance from the table's edge to the card's edge
-      const distanceLeft = Math.abs(tableLeft - cardLeft);
-      const distanceTop = Math.abs(tableTop - cardTop);
+      // Convert the card center from screen pixels back to board pixels (the
+      // board is scaled by `scale` around its top-left origin, so 1 screen px ==
+      // 1/scale board px), then find which cell contains that point.
+      const boardLeft = Math.abs(tableLeft - cardCenterLeft) / scale;
+      const boardTop = Math.abs(tableTop - cardCenterTop) / scale;
 
-      // Calculate the total distance in "cells"
-      const cellsFromLeft = Math.round(distanceLeft / cardWidth);
-      const cellsFromTop = Math.round(distanceTop / cardHeight);
+      const cellsFromLeft = Math.floor(boardLeft / cardWidth);
+      const cellsFromTop = Math.floor(boardTop / cardHeight);
 
       // Calculate the target cell's id
       const targetCell = cellsFromTop * columns + cellsFromLeft;

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -11,35 +11,56 @@ import WoodBackground from "./wood-background.jpg";
 import { boardHeight, boardWidth } from "../constants/board";
 import Board from "../Board";
 
+// MIN_ZOOM stays high enough that the scaled board is always larger than the
+// viewport (boardWidth/Height are thousands of px), which keeps the boundary
+// clamp from inverting. MAX_ZOOM lets players read individual cards.
+const MIN_ZOOM = 0.75;
+const MAX_ZOOM = 1.5;
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const distanceBetween = (a, b) =>
+  Math.hypot(a.pageX - b.pageX, a.pageY - b.pageY);
+
+const midpointOf = (a, b) => ({
+  x: (a.pageX + b.pageX) / 2,
+  y: (a.pageY + b.pageY) / 2,
+});
+
 class Table extends Component {
   constructor(props) {
     super(props);
 
     const { height, width } = Dimensions.get("window");
-    this._boundaries = {
-      top: 0,
-      right: -(boardWidth - width),
-      bottom: -(boardHeight - height),
-      left: 0,
-    };
+    this._viewport = { height, width };
     this._centeredWindow = {
       top: -((boardHeight - height) / 2),
       left: -((boardWidth - width) / 2),
     };
 
-    // _previousLeft/_previousTop are read by Matchimals' onCardDrop to map a
-    // dropped card's screen position to a board cell- keep them up to date.
+    // _previousLeft/_previousTop/_previousScale describe the committed (settled)
+    // transform. Matchimals' onCardDrop reads them to map a dropped card's
+    // screen position to a board cell- keep them up to date on every release.
     this._previousLeft =
       (props.style && props.style.left) || this._centeredWindow.left || 0;
     this._previousTop =
       (props.style && props.style.top) || this._centeredWindow.top || 0;
+    this._previousScale = 1;
 
-    // Pan with translate transforms instead of mutating left/top layout
-    // props- layout mutation via setNativeProps is unreliable on Fabric.
+    // Per-gesture baselines, reset whenever the active touch count changes so
+    // adding/lifting a finger never causes a jump. _lastSingle tracks the pan
+    // finger frame-to-frame; _pinch tracks the two-finger distance/midpoint.
+    this._lastTouchCount = 0;
+    this._lastSingle = null;
+    this._pinch = null;
+
+    // Pan/zoom with translate+scale transforms instead of mutating left/top
+    // layout props- layout mutation via setNativeProps is unreliable on Fabric.
     this._pan = new Animated.ValueXY({
       x: this._previousLeft,
       y: this._previousTop,
     });
+    this._scale = new Animated.Value(this._previousScale);
 
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
@@ -51,42 +72,97 @@ class Table extends Component {
   }
 
   scrollToCenter() {
+    this._previousScale = 1;
     this._previousLeft = this._centeredWindow.left || 0;
     this._previousTop = this._centeredWindow.top || 0;
+    this._scale.setValue(1);
     this._pan.setValue({ x: this._previousLeft, y: this._previousTop });
   }
 
-  _clampToBoundaries(left, top) {
+  // Boundaries depend on the current scale: the on-screen board is
+  // boardWidth*scale wide, so it can pan until its far edge meets the viewport.
+  _clampToBoundaries(left, top, scale) {
+    const { height, width } = this._viewport;
+    const right = -(boardWidth * scale - width);
+    const bottom = -(boardHeight * scale - height);
     return {
-      left: Math.min(
-        this._boundaries.left,
-        Math.max(this._boundaries.right, left)
-      ),
-      top: Math.min(
-        this._boundaries.top,
-        Math.max(this._boundaries.bottom, top)
-      ),
+      left: Math.min(0, Math.max(right, left)),
+      top: Math.min(0, Math.max(bottom, top)),
     };
   }
 
   _handlePanResponderMove = (e, gestureState) => {
-    if (gestureState.numberActiveTouches === 1) {
-      const { left, top } = this._clampToBoundaries(
-        this._previousLeft + gestureState.dx,
-        this._previousTop + gestureState.dy
-      );
-      this._pan.setValue({ x: left, y: top });
+    const touches = e.nativeEvent.touches;
+
+    // Reset the per-gesture baselines when the finger count changes.
+    if (touches.length !== this._lastTouchCount) {
+      this._lastTouchCount = touches.length;
+      this._lastSingle = null;
+      this._pinch = null;
+    }
+
+    if (touches.length >= 2) {
+      this._handlePinch(touches[0], touches[1]);
+    } else if (touches.length === 1) {
+      this._handlePan(touches[0]);
     }
   };
 
-  _handlePanResponderEnd = (e, gestureState) => {
+  _handlePan = (touch) => {
+    const point = { x: touch.pageX, y: touch.pageY };
+    if (this._lastSingle === null) {
+      this._lastSingle = point;
+      return;
+    }
     const { left, top } = this._clampToBoundaries(
-      this._previousLeft + gestureState.dx,
-      this._previousTop + gestureState.dy
+      this._previousLeft + (point.x - this._lastSingle.x),
+      this._previousTop + (point.y - this._lastSingle.y),
+      this._previousScale
     );
     this._previousLeft = left;
     this._previousTop = top;
+    this._lastSingle = point;
     this._pan.setValue({ x: left, y: top });
+  };
+
+  _handlePinch = (a, b) => {
+    const distance = distanceBetween(a, b);
+    const midpoint = midpointOf(a, b);
+    if (this._pinch === null) {
+      this._pinch = { distance, midpoint };
+      return;
+    }
+
+    const scale = this._previousScale;
+    const nextScale = clamp(
+      scale * (distance / this._pinch.distance),
+      MIN_ZOOM,
+      MAX_ZOOM
+    );
+    // Pin the board point under the previous midpoint to the new midpoint, so
+    // the gesture zooms toward the fingers and pans as they slide.
+    const { left, top } = this._clampToBoundaries(
+      midpoint.x -
+        (nextScale * (this._pinch.midpoint.x - this._previousLeft)) / scale,
+      midpoint.y -
+        (nextScale * (this._pinch.midpoint.y - this._previousTop)) / scale,
+      nextScale
+    );
+
+    this._previousScale = nextScale;
+    this._previousLeft = left;
+    this._previousTop = top;
+    this._pinch = { distance, midpoint };
+    this._scale.setValue(nextScale);
+    this._pan.setValue({ x: left, y: top });
+  };
+
+  _handlePanResponderEnd = () => {
+    // Running values are committed continuously during the gesture; just clear
+    // the per-gesture baselines so the next gesture starts clean.
+    this._lastTouchCount = 0;
+    this._lastSingle = null;
+    this._pinch = null;
   };
 
   render() {
@@ -97,9 +173,11 @@ class Table extends Component {
         style={[
           styles.root,
           {
+            transformOrigin: "top left",
             transform: [
               { translateX: this._pan.x },
               { translateY: this._pan.y },
+              { scale: this._scale },
             ],
           },
         ]}


### PR DESCRIPTION
Fixes https://github.com/igravitystudios/matchimals.fun/issues/27

## What

Adds two-finger pinch-to-zoom to the game board, alongside the existing one-finger pan. Dependency-free — extends the `Table`'s built-in `PanResponder`/`Animated` setup, no gesture-handler/reanimated and no native rebuild. iOS-focused.

## How

- **`src/Table/index.js`** — `_handlePanResponderMove` branches on `e.nativeEvent.touches`: one finger pans, two fingers pinch. Pinch scales by the ratio of finger distances (clamped to **0.75–1.5**) and pins the board point under the gesture midpoint to the moving midpoint, so it zooms toward the fingers. Per-gesture baselines reset whenever the touch count changes, so adding/lifting a finger never jumps. Boundaries are now scale-aware, and the board scales from a `top left` transform origin.
- **`src/Matchimals/index.js`** — `onCardDrop` converts the dragged card's **center** back to board pixels (`/ scale`) and floors into a cell. Using the center instead of the top-left corner keeps drops accurate when zoomed out, where the full-size deck card visually covers several smaller board cells. At zoom == 1 this is mathematically identical to the previous top-left + round, so un-zoomed behavior is unchanged.

## Testing

Verified manually in the iOS simulator: pinch zoom tracks the fingers, one-finger pan still works, finger add/lift transitions don't jump, and cards drop on the cell under their center at min and max zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)