### PR TITLE
Various fixes: smooth nameplate transition & lag-free Dialog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,6 @@
         "react-native": "0.85.3",
         "react-native-animatable": "^1.4.0",
         "react-native-in-app-review": "^4.3.0",
-        "react-native-modal": "14.0.0-rc.1",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-svg": "15.15.4",
         "react-native-web": "^0.21.2",
@@ -1564,8 +1563,6 @@
     "react-native-animatable": ["react-native-animatable@1.4.0", "", { "dependencies": { "prop-types": "^15.8.1" } }, "sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw=="],
 
     "react-native-in-app-review": ["react-native-in-app-review@4.4.2", "", {}, "sha512-iUoZnP4cgpbiNMLpqPgK40AcT7xluJhlwEPKFEfcCZsWT4MzGygS8p1dxf6e1NH/LUgUEtjsZQ8ka/SbF1pE8Q=="],
-
-    "react-native-modal": ["react-native-modal@14.0.0-rc.1", "", { "dependencies": { "react-native-animatable": "1.4.0" }, "peerDependencies": { "react": "*", "react-native": ">=0.70.0" } }, "sha512-v5pvGyx1FlmBzdHyPqBsYQyS2mIJhVmuXyNo5EarIzxicKhuoul6XasXMviGcXboEUT0dTYWs88/VendojPiVw=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@5.7.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react-native": "0.85.3",
     "react-native-animatable": "^1.4.0",
     "react-native-in-app-review": "^4.3.0",
-    "react-native-modal": "14.0.0-rc.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-svg": "15.15.4",
     "react-native-web": "^0.21.2",

--- a/src/App.js
+++ b/src/App.js
@@ -10,16 +10,15 @@ import game from "./Matchimals/game";
 import MainMenu from "./MainMenu";
 import { MusicProvider } from "./Music";
 import { PlayerProvider } from "./hooks/players";
+import { OverlayProvider } from "./Overlay";
 
 export default function App() {
   const [isMainMenuVisible, setIsMainMenuVisible] = React.useState(true);
   const [numPlayers, setNumPlayers] = React.useState(1);
 
   const [numGamesPlayed, setNumGamesPlayed] = React.useState("0");
-  const {
-    getItem: getAsyncNumGamesPlayed,
-    setItem: setAsyncNumGamesPlayed,
-  } = useAsyncStorage("numGamesPlayed");
+  const { getItem: getAsyncNumGamesPlayed, setItem: setAsyncNumGamesPlayed } =
+    useAsyncStorage("numGamesPlayed");
 
   const onMount = async () => {
     const asyncNumGamesPlayed = await getAsyncNumGamesPlayed();
@@ -62,14 +61,16 @@ export default function App() {
     <SafeAreaProvider>
       <MusicProvider>
         <PlayerProvider>
-          <View style={styles.root}>
-            <StatusBar hidden />
-            {isMainMenuVisible ? (
-              <MainMenu startGame={startGame} />
-            ) : (
-              <MatchimalsClient backToMainMenu={backToMainMenu} />
-            )}
-          </View>
+          <OverlayProvider>
+            <View style={styles.root}>
+              <StatusBar hidden />
+              {isMainMenuVisible ? (
+                <MainMenu startGame={startGame} />
+              ) : (
+                <MatchimalsClient backToMainMenu={backToMainMenu} />
+              )}
+            </View>
+          </OverlayProvider>
         </PlayerProvider>
       </MusicProvider>
     </SafeAreaProvider>

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,57 +1,123 @@
-import React from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
-import Modal from "react-native-modal";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  Easing,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { Portal } from "../Overlay";
 import Animals from "../Animals";
 import { usePlayerConfig } from "../hooks/players";
 
 const Dialog = ({ children, isVisible, hide, player = 0, style }) => {
   const insets = useSafeAreaInsets();
+  const { width, height } = useWindowDimensions();
   const { playerConfig } = usePlayerConfig();
   const Icon = Animals[playerConfig[player].animal];
   const backgroundColor = playerConfig[player].color;
+
+  // Keep the dialog mounted while it animates out, then unmount it. `progress`
+  // drives both the backdrop fade and the card's slide-up via the native driver.
+  const [mounted, setMounted] = useState(isVisible);
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (isVisible) {
+      setMounted(true);
+    }
+  }, [isVisible]);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+    const animation = Animated.timing(progress, {
+      toValue: isVisible ? 1 : 0,
+      duration: isVisible ? 240 : 180,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    });
+    animation.start(({ finished }) => {
+      if (finished && !isVisible) {
+        setMounted(false);
+      }
+    });
+    return () => animation.stop();
+  }, [mounted, isVisible, progress]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const translateY = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [60, 0],
+  });
+
   return (
-    <Modal
-      isVisible={isVisible}
-      onBackButtonPress={hide}
-      onBackdropPress={hide}
-      onSwipeComplete={hide}
-      style={styles.modal}
-      useNativeDriver={true}
-      hideModalContentWhileAnimating={true}
-    >
-      <View
-        style={[
-          styles.dialog,
-          { marginTop: insets.top + 60, marginBottom: insets.bottom },
-          style,
-        ]}
+    <Portal>
+      <Animated.View
+        style={[styles.modal, { width, height, opacity: progress }]}
       >
-        <ScrollView contentContainerStyle={{ paddingTop: 60 }}>
-          {children}
-        </ScrollView>
-        <View
+        {/* Full-screen dismiss layer behind the card. Explicit width/height-
+            absoluteFill collapses to zero inside the portal host. */}
+        <TouchableOpacity
+          activeOpacity={1} // No feedback, the dialog closing is the feedback
+          onPress={hide}
+          style={[styles.dismiss, { width, height }]}
+        />
+        <Animated.View
           style={[
-            styles.animal,
-            { backgroundColor: backgroundColor || "gray" },
+            styles.dialog,
+            { marginTop: insets.top + 60, marginBottom: insets.bottom },
+            { transform: [{ translateY }] },
+            style,
           ]}
         >
-          <Icon width={80} height={80} />
-        </View>
-      </View>
-    </Modal>
+          <ScrollView contentContainerStyle={{ paddingTop: 60 }}>
+            {children}
+          </ScrollView>
+          <View
+            style={[
+              styles.animal,
+              { backgroundColor: backgroundColor || "gray" },
+            ]}
+          >
+            <Icon width={80} height={80} />
+          </View>
+        </Animated.View>
+      </Animated.View>
+    </Portal>
   );
 };
 
 const styles = StyleSheet.create({
+  // Explicit width/height (set inline from useWindowDimensions) instead of
+  // absoluteFillObject's right/bottom: 0, which collapse to zero inside the
+  // portal host. This view is both the (fading) backdrop and the centering
+  // container.
   modal: {
+    position: "absolute",
+    top: 0,
+    left: 0,
     alignItems: "center",
     justifyContent: "center",
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  dismiss: {
+    position: "absolute",
+    top: 0,
+    left: 0,
   },
   dialog: {
     flexDirection: "row",
     alignItems: "center",
+    marginHorizontal: 16,
     backgroundColor: "#fff",
     borderRadius: 16,
     padding: 8,

--- a/src/Nameplate/index.js
+++ b/src/Nameplate/index.js
@@ -1,6 +1,11 @@
-import React, { useState } from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
-import * as Animatable from "react-native-animatable";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import Animals from "../Animals";
 import { usePlayerConfig } from "../hooks/players";
 import AnimalChooser from "../AnimalChooser";
@@ -14,11 +19,32 @@ const Nameplate = ({ player, players, currentPlayer, style, ...rest }) => {
   const backgroundColor = playerConfig[player]?.color;
   const Icon = Animals[playerConfig[player]?.animal];
 
+  // Drive the active/inactive transition with the core Animated API on the
+  // native driver- react-native-animatable's `transition` prop oscillates on
+  // the New Architecture (Fabric). Start at the resting value so plates that
+  // mount inactive don't animate in.
+  const progress = useRef(new Animated.Value(active ? 1 : 0)).current;
+  useEffect(() => {
+    Animated.timing(progress, {
+      toValue: active ? 1 : 0,
+      duration: 200,
+      useNativeDriver: true,
+    }).start();
+  }, [active, progress]);
+
+  const opacity = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.8, 1],
+  });
+  const scale = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.8, 1],
+  });
+
   return (
     <>
-      <Animatable.View
-        style={[styles.root, active ? styles.active : styles.inactive, style]}
-        transition={["opacity", "scaleX", "scaleY"]}
+      <Animated.View
+        style={[styles.root, { opacity, transform: [{ scale }] }, style]}
         {...rest}
       >
         <TouchableOpacity
@@ -40,7 +66,7 @@ const Nameplate = ({ player, players, currentPlayer, style, ...rest }) => {
           <Text style={styles.name}>{name}</Text>
           <Text style={styles.score}>{score}</Text>
         </View>
-      </Animatable.View>
+      </Animated.View>
       <AnimalChooser
         isVisible={showAnimalChooser}
         hide={() => setShowAnimalChooser(false)}
@@ -67,11 +93,6 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     borderRadius: 40,
-  },
-  active: {},
-  inactive: {
-    opacity: 0.8,
-    transform: [{ scaleX: 0.8 }, { scaleY: 0.8 }],
   },
   details: {
     width: 120,

--- a/src/Overlay/index.js
+++ b/src/Overlay/index.js
@@ -1,0 +1,70 @@
+import React, { Fragment, useEffect, useId, useReducer } from "react";
+import { StyleSheet, View } from "react-native";
+
+// A dependency-free portal for native. RN has no createPortal for native, and
+// its built-in Modal collapses its content frame on the New Architecture
+// (Fabric), which breaks full-screen overlays. Instead we keep the mounted
+// overlays in a tiny module-level store and render them in a single full-screen
+// host at the app root. The store is deliberately OUTSIDE React state so that
+// mounting/updating an overlay only re-renders the host- never the whole app
+// (which previously caused an infinite render loop). Because the host lives
+// below the app's providers, portaled content still sees PlayerProvider, Music,
+// safe-area, etc.
+
+let overlays = {};
+const listeners = new Set();
+const emit = () => listeners.forEach((notify) => notify());
+
+const setOverlay = (id, node) => {
+  overlays = { ...overlays, [id]: node };
+  emit();
+};
+
+const removeOverlay = (id) => {
+  const next = { ...overlays };
+  delete next[id];
+  overlays = next;
+  emit();
+};
+
+const OverlayHost = () => {
+  const [, force] = useReducer((n) => n + 1, 0);
+  useEffect(() => {
+    listeners.add(force);
+    return () => {
+      listeners.delete(force);
+    };
+  }, []);
+
+  return (
+    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+      {Object.entries(overlays).map(([id, node]) => (
+        <Fragment key={id}>{node}</Fragment>
+      ))}
+    </View>
+  );
+};
+
+// Renders the host alongside the app. No React state here, so it never forces
+// the app subtree to re-render.
+export const OverlayProvider = ({ children }) => (
+  <>
+    {children}
+    <OverlayHost />
+  </>
+);
+
+// Renders nothing in place; mounts its children into the host instead. Children
+// are refreshed on every render so their closures (and Animated values) stay
+// current; this only re-renders the host, not this component's parent.
+export const Portal = ({ children }) => {
+  const id = useId();
+
+  useEffect(() => {
+    setOverlay(id, children);
+  });
+
+  useEffect(() => () => removeOverlay(id), [id]);
+
+  return null;
+};


### PR DESCRIPTION
A couple of New Architecture (Fabric) fixes uncovered after the Expo SDK 56 / RN 0.85 migration.

## Nameplate transition (`666b4460`)
In 2+ player games the nameplate scale/opacity animation went haywire when the turn changed — rapidly swapping back and forth. Cause: `react-native-animatable`'s `transition` prop oscillates on Fabric. Replaced it with the core `Animated` API on the native driver (a single `progress` value interpolating opacity `0.8→1` and scale `0.8→1`), restoring one smooth grow/shrink per change.

## Dialog overlay (`910bb040`)
`react-native-modal` was noticeably laggy, and RN's built-in `Modal` collapses its content frame on Fabric, so a full-screen overlay couldn't be styled reliably. Removed the dependency and reimplemented the Dialog:

- **`src/Overlay`** — a tiny dependency-free portal. Overlays live in a module-level store and render into a single full-screen host at the app root, so deeply-nested dialogs escape their layout parent while keeping app context (PlayerProvider, Music, safe-area). The store sits outside React state, avoiding the render loop a naive context portal causes.
- **Native Dialog** — its own presentation: a fading dim backdrop + slide-up card via `Animated` (native driver), an animated exit before unmount, and tap-outside-to-dismiss. Uses explicit window dimensions (`useWindowDimensions`) instead of `absoluteFill`, which collapses inside the host.

Web Dialog is unchanged (the lag was native-only).

## Testing
- `bun run ios`: 2–4 player games — nameplate transitions are smooth across turns and restarts.
- Open the Menu (`?`) and the AnimalChooser (tap a nameplate): backdrop fades in, card slides up centered, tap-outside dismisses — no lag.
- `bun run web`: dialogs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)