### PR TITLE
chore: hardening follow-ups from the post-migration audit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.85.3",
-        "react-native-animatable": "^1.4.0",
         "react-native-gesture-handler": "~2.31.1",
         "react-native-in-app-review": "^4.3.0",
         "react-native-reanimated": "4.3.1",
@@ -1587,8 +1586,6 @@
     "react-is": ["react-is@19.2.7", "", {}, "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A=="],
 
     "react-native": ["react-native@0.85.3", "", { "dependencies": { "@react-native/assets-registry": "0.85.3", "@react-native/codegen": "0.85.3", "@react-native/community-cli-plugin": "0.85.3", "@react-native/gradle-plugin": "0.85.3", "@react-native/js-polyfills": "0.85.3", "@react-native/normalize-colors": "0.85.3", "@react-native/virtualized-lists": "0.85.3", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-plugin-syntax-hermes-parser": "0.33.3", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "hermes-compiler": "250829098.0.10", "invariant": "^2.2.4", "memoize-one": "^5.0.0", "metro-runtime": "^0.84.3", "metro-source-map": "^0.84.3", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.27.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "tinyglobby": "^0.2.15", "whatwg-fetch": "^3.0.0", "ws": "^7.5.10", "yargs": "^17.6.2" }, "peerDependencies": { "@react-native/jest-preset": "0.85.3", "@types/react": "^19.1.1", "react": "^19.2.3" }, "optionalPeers": ["@react-native/jest-preset", "@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA=="],
-
-    "react-native-animatable": ["react-native-animatable@1.4.0", "", { "dependencies": { "prop-types": "^15.8.1" } }, "sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw=="],
 
     "react-native-gesture-handler": ["react-native-gesture-handler@2.31.2", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "@types/react-test-renderer": "^19.1.0", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-rw5q74i2AfS7YGYdbxQDhOU7xqgY6WRM1132/CCm3erqjblhECZDZFHIm0tteHoC9ih24wogVBVVzcTBQtZ+5A=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-animatable": "^1.4.0",
     "react-native-gesture-handler": "~2.31.1",
     "react-native-in-app-review": "^4.3.0",
     "react-native-reanimated": "4.3.1",

--- a/src/Card/index.js
+++ b/src/Card/index.js
@@ -39,7 +39,7 @@ const Card = ({ card = {}, disabled, flipped, onCardDrop, style, ...rest }) => {
         return;
       }
       cardRef.current.measureInWindow((pageX, pageY, width, height) => {
-        onCardDrop({ pageX, pageY, width, height }).then(reset);
+        onCardDrop({ pageX, pageY, width, height }).then(reset, reset);
       });
     },
     [onCardDrop, reset]

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -74,7 +74,14 @@ const Dialog = ({ children, isVisible, hide, player = 0, style }) => {
         <Animated.View
           style={[
             styles.dialog,
-            { marginTop: insets.top + 60, marginBottom: insets.bottom },
+            {
+              marginTop: insets.top + 60,
+              marginBottom: insets.bottom,
+              // Cap the card so tall content scrolls instead of overflowing
+              // the screen (the web variant caps at calc(100vh - 120px)); the
+              // extra 60 leaves room for the animal badge poking out the top.
+              maxHeight: height - insets.top - insets.bottom - 120,
+            },
             { transform: [{ translateY }] },
             style,
           ]}

--- a/src/Matchimals/game.js
+++ b/src/Matchimals/game.js
@@ -119,9 +119,11 @@ export function getInitialState(ctx) {
     players: {},
   };
 
-  // Add a deck for every player
+  // Add a deck for every player. Copy each card so G never holds the shared
+  // constants/cards.js objects — Immer's dev freeze would freeze them after the
+  // first game (same read-only hazard as the emptyCells copy below).
   for (let i = 0; i < ctx.numPlayers; i++) {
-    G.deck = G.deck.concat(deck);
+    G.deck = G.deck.concat(deck.map((card) => ({ ...card })));
   }
 
   // Shuffle resulting deck using lodash
@@ -139,8 +141,8 @@ export function getInitialState(ctx) {
   // makes `emptyCells` read-only and the next game throws on G.cells[center] = …
   G.cells = [...emptyCells];
 
-  // Set the initial card on the board
-  const initialCard = getRandomCard(deck); // TODO: Use boardgame.io provided random function
+  // Set the initial card on the board (copied off the shared constants too)
+  const initialCard = { ...getRandomCard(deck) }; // TODO: Use boardgame.io provided random function
   G.cells[center] = initialCard;
 
   // Ensure the first card is connectable
@@ -204,12 +206,11 @@ const game = {
 
   endIf: (G, ctx) => {
     if (G.deck.length === 0) {
-      const winner = Object.keys(
-        G.players
-      ).reduce((previousPlayer, currentPlayer) =>
-        G.players[previousPlayer].score > G.players[currentPlayer].score
-          ? previousPlayer
-          : currentPlayer
+      const winner = Object.keys(G.players).reduce(
+        (previousPlayer, currentPlayer) =>
+          G.players[previousPlayer].score > G.players[currentPlayer].score
+            ? previousPlayer
+            : currentPlayer
       );
       return winner;
     }


### PR DESCRIPTION
## Summary

An audit of the four commits since the Expo SDK 56 migration (#67–#70) found the implementations sound — pinch focal math, boundary clamps, zoom-adjusted drop-to-cell conversion, and dependency versions all check out. This PR applies the small hardening follow-ups it surfaced:

- **Remove `react-native-animatable`** — no imports remain after the Nameplate rewrite in #69 (only a comment references it). Pure-JS lib, so no native rebuild needed.
- **Card: reset on rejected drop** — `onCardDrop(...).then(reset)` never reset the dragged card if the promise rejected, stranding it mid-board. Now resets on both paths.
- **game.js: copy cards off the shared constants** — `G.deck` and the initial center card held references to the module-level `constants/cards.js` objects, so Immer's dev freeze froze the constants after game 1. Same hazard class as the `emptyCells` restart crash fixed in #67; dormant today (cards are never mutated) but a landmine.
- **Dialog (native): cap the card height** — derived from window height + safe-area insets, mirroring the web variant's `calc(100vh - 120px)`, so tall content scrolls instead of overflowing on small phones.

## Testing

- `bun run format` clean; `bun run build:web` exports successfully.
- ⚠️ Still pending: a manual iOS pass for #70's gesture rewrite (it was only validated via web export) — verify drag-drop lands on the aimed cell at zoom 0.75/1/1.5, pinch stays pinned under the fingers, and restart a finished game twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)