### PR TITLE
feat: Easy Mode / Classic game modes with guaranteed-playable draws

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import { Client } from "boardgame.io/react-native";
 import { colors } from "./constants/colors";
 
 import Matchimals from "./Matchimals";
-import game from "./Matchimals/game";
+import { createGame } from "./Matchimals/game";
+import type { GameMode } from "./Matchimals/game";
 import MainMenu from "./MainMenu";
 import { MusicProvider } from "./Music";
 import { PlayerProvider } from "./hooks/players";
@@ -20,6 +21,28 @@ export default function App() {
   const [numGamesPlayed, setNumGamesPlayed] = React.useState("0");
   const { getItem: getAsyncNumGamesPlayed, setItem: setAsyncNumGamesPlayed } =
     useAsyncStorage("numGamesPlayed");
+
+  const [gameMode, setGameMode] = React.useState<GameMode>("kids");
+  const { getItem: getAsyncGameMode, setItem: setAsyncGameMode } =
+    useAsyncStorage("gameMode");
+
+  // Hydrate the last-chosen mode once on mount (defaults to kids)
+  useEffect(() => {
+    getAsyncGameMode().then((storedMode) => {
+      if (storedMode === "kids" || storedMode === "classic") {
+        setGameMode(storedMode);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSetGameMode = useCallback(
+    (mode: GameMode) => {
+      setGameMode(mode);
+      setAsyncGameMode(mode);
+    },
+    [setAsyncGameMode]
+  );
 
   const onMount = async () => {
     const asyncNumGamesPlayed = await getAsyncNumGamesPlayed();
@@ -53,7 +76,7 @@ export default function App() {
 
   const MatchimalsClient = Client({
     board: Matchimals,
-    game,
+    game: createGame(gameMode),
     numPlayers,
     debug: false,
   });
@@ -67,7 +90,11 @@ export default function App() {
               <View style={styles.root}>
                 <StatusBar hidden />
                 {isMainMenuVisible ? (
-                  <MainMenu startGame={startGame} />
+                  <MainMenu
+                    startGame={startGame}
+                    gameMode={gameMode}
+                    setGameMode={handleSetGameMode}
+                  />
                 ) : (
                   <MatchimalsClient backToMainMenu={backToMainMenu} />
                 )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,14 +22,14 @@ export default function App() {
   const { getItem: getAsyncNumGamesPlayed, setItem: setAsyncNumGamesPlayed } =
     useAsyncStorage("numGamesPlayed");
 
-  const [gameMode, setGameMode] = React.useState<GameMode>("kids");
+  const [gameMode, setGameMode] = React.useState<GameMode>("easy");
   const { getItem: getAsyncGameMode, setItem: setAsyncGameMode } =
     useAsyncStorage("gameMode");
 
-  // Hydrate the last-chosen mode once on mount (defaults to kids)
+  // Hydrate the last-chosen mode once on mount (defaults to easy)
   useEffect(() => {
     getAsyncGameMode().then((storedMode) => {
-      if (storedMode === "kids" || storedMode === "classic") {
+      if (storedMode === "easy" || storedMode === "classic") {
         setGameMode(storedMode);
       }
     });

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -23,7 +23,7 @@ import Toggle from "../Toggle";
 import type { GameMode } from "../Matchimals/game";
 
 const modeCaptions: Record<GameMode, string> = {
-  kids: "Always a match to make",
+  easy: "Always a match to make",
   classic: "Match if you can, pass if not",
 };
 
@@ -94,7 +94,7 @@ const Menu = ({
 
         <Toggle
           options={[
-            { label: "KID'S MODE", value: "kids" },
+            { label: "EASY MODE", value: "easy" },
             { label: "CLASSIC", value: "classic" },
           ]}
           value={gameMode}

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -23,8 +23,8 @@ import Toggle from "../Toggle";
 import type { GameMode } from "../Matchimals/game";
 
 const modeCaptions: Record<GameMode, string> = {
-  kids: "Frustration-free: each card can always be placed",
-  classic: "Shuffled deck: play if it fits, pass if it doesn't",
+  kids: "Always a match to make",
+  classic: "Match if you can, pass if not",
 };
 
 const Menu = ({
@@ -149,8 +149,8 @@ const styles = StyleSheet.create({
     lineHeight: 28,
     marginTop: 12,
     width: 320,
-    // Reserve two lines so switching captions never shifts the layout
-    height: 56,
+    // Both captions are single-line; fixed height keeps the layout stable
+    height: 28,
     textAlign: "center",
   },
 });

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -14,8 +14,17 @@ import Button from "../Button";
 import PlayerButton from "../PlayerButton";
 import { useMusic } from "../Music";
 import Logo from "../Logo";
+import type { GameMode } from "../Matchimals/game";
 
-const Menu = ({ startGame }: { startGame: (numPlayers: number) => void }) => {
+const Menu = ({
+  startGame,
+  gameMode,
+  setGameMode,
+}: {
+  startGame: (numPlayers: number) => void;
+  gameMode: GameMode;
+  setGameMode: (mode: GameMode) => void;
+}) => {
   const music = useMusic();
   const insets = useSafeAreaInsets();
 
@@ -59,6 +68,25 @@ const Menu = ({ startGame }: { startGame: (numPlayers: number) => void }) => {
             }}
             style={{ margin: 6 }}
           />
+        </View>
+
+        <View style={{ flexDirection: "row", marginTop: 24 }}>
+          <Button
+            color={gameMode === "kids" ? colors.yellowLight : colors.grayLight}
+            onPress={() => setGameMode("kids")}
+            style={{ margin: 6 }}
+          >
+            KID'S MODE
+          </Button>
+          <Button
+            color={
+              gameMode === "classic" ? colors.yellowLight : colors.grayLight
+            }
+            onPress={() => setGameMode("classic")}
+            style={{ margin: 6 }}
+          >
+            CLASSIC
+          </Button>
         </View>
 
         {Platform.OS !== "web" && music && (

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   ImageBackground,
   Platform,
@@ -7,6 +7,11 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Reanimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 
 import TriangleBackground from "./trianglify.png";
 import { colors } from "../constants/colors";
@@ -16,6 +21,11 @@ import { useMusic } from "../Music";
 import Logo from "../Logo";
 import Toggle from "../Toggle";
 import type { GameMode } from "../Matchimals/game";
+
+const modeCaptions: Record<GameMode, string> = {
+  kids: "Every card you draw can be placed",
+  classic: "Cards come as shuffled — pass the ones that don't fit",
+};
 
 const Menu = ({
   startGame,
@@ -28,6 +38,17 @@ const Menu = ({
 }) => {
   const music = useMusic();
   const insets = useSafeAreaInsets();
+
+  // Fade the caption back in whenever the mode (and its text) changes
+  const captionOpacity = useSharedValue(0);
+  useEffect(() => {
+    captionOpacity.value = 0;
+    captionOpacity.value = withTiming(1, { duration: 350 });
+  }, [gameMode, captionOpacity]);
+
+  const captionStyle = useAnimatedStyle(() => ({
+    opacity: captionOpacity.value,
+  }));
 
   return (
     <ImageBackground source={TriangleBackground} style={styles.root}>
@@ -80,6 +101,9 @@ const Menu = ({
           onChange={setGameMode}
           style={{ marginTop: 24 }}
         />
+        <Reanimated.Text style={[styles.caption, captionStyle]}>
+          {modeCaptions[gameMode]}
+        </Reanimated.Text>
 
         {Platform.OS !== "web" && music && (
           <Button
@@ -116,6 +140,18 @@ const styles = StyleSheet.create({
     fontSize: 48,
     lineHeight: 60,
     marginBottom: 32,
+  },
+  caption: {
+    // Muted vs the heading — the animated fade owns the opacity prop
+    color: colors.grayMedium,
+    fontFamily: "Dimbo",
+    fontSize: 22,
+    lineHeight: 28,
+    marginTop: 12,
+    width: 320,
+    // Reserve two lines so switching captions never shifts the layout
+    height: 56,
+    textAlign: "center",
   },
 });
 

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -23,8 +23,8 @@ import Toggle from "../Toggle";
 import type { GameMode } from "../Matchimals/game";
 
 const modeCaptions: Record<GameMode, string> = {
-  kids: "Every card you draw can be placed",
-  classic: "Cards come as shuffled — pass the ones that don't fit",
+  kids: "Frustration-free: each card can always be placed",
+  classic: "Shuffled deck: play if it fits, pass if it doesn't",
 };
 
 const Menu = ({

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -14,6 +14,7 @@ import Button from "../Button";
 import PlayerButton from "../PlayerButton";
 import { useMusic } from "../Music";
 import Logo from "../Logo";
+import Toggle from "../Toggle";
 import type { GameMode } from "../Matchimals/game";
 
 const Menu = ({
@@ -70,24 +71,15 @@ const Menu = ({
           />
         </View>
 
-        <View style={{ flexDirection: "row", marginTop: 24 }}>
-          <Button
-            color={gameMode === "kids" ? colors.yellowLight : colors.grayLight}
-            onPress={() => setGameMode("kids")}
-            style={{ margin: 6 }}
-          >
-            KID'S MODE
-          </Button>
-          <Button
-            color={
-              gameMode === "classic" ? colors.yellowLight : colors.grayLight
-            }
-            onPress={() => setGameMode("classic")}
-            style={{ margin: 6 }}
-          >
-            CLASSIC
-          </Button>
-        </View>
+        <Toggle
+          options={[
+            { label: "KID'S MODE", value: "kids" },
+            { label: "CLASSIC", value: "classic" },
+          ]}
+          value={gameMode}
+          onChange={setGameMode}
+          style={{ marginTop: 24 }}
+        />
 
         {Platform.OS !== "web" && music && (
           <Button

--- a/src/Matchimals/game.ts
+++ b/src/Matchimals/game.ts
@@ -10,11 +10,18 @@ export interface PlayerState {
   score: number;
 }
 
+// "kids": the deck always surfaces a playable card (and a dead deck ends the
+// game). "classic": only the first card is guaranteed; unplayable cards are
+// PASSed, but a fully dead deck still ends the game instead of looping forever.
+export type GameMode = "kids" | "classic";
+
 export interface GameState {
   cells: (Card | null)[];
   deck: Card[];
   players: Record<string, PlayerState>;
-  // Optional so hardcoded snapshot states don't need to carry it
+  // Both optional so hardcoded snapshot states don't need to carry them;
+  // an undefined mode behaves as "kids"
+  mode?: GameMode;
   noValidMoves?: boolean;
 }
 
@@ -84,12 +91,15 @@ export function calculateScore(G: GameState, ctx: Ctx, id: number): number {
   return score;
 }
 
-export function isLegalMove(G: GameState, ctx: Ctx, id: number): boolean {
+export function isLegalMove(
+  G: GameState,
+  ctx: Ctx,
+  id: number,
+  currentCard: Card = G.deck[0]
+): boolean {
   if (G.cells[id] !== null) {
     return false;
   }
-
-  const currentCard = G.deck[0];
 
   //Assign neighbors
   const neighbors = getNeighbors(G, id);
@@ -120,12 +130,20 @@ export function isLegalMove(G: GameState, ctx: Ctx, id: number): boolean {
   return false; //Return false if there are no neighboring cards that match
 }
 
+export function cardHasAnyLegalMove(
+  G: GameState,
+  ctx: Ctx,
+  card: Card
+): boolean {
+  return G.cells.some((_, id) => isLegalMove(G, ctx, id, card));
+}
+
 export function hasAnyLegalMove(G: GameState, ctx: Ctx): boolean {
-  // No card to play — isLegalMove reads G.deck[0], so guard the empty deck
+  // No card to play — no legal move
   if (G.deck.length === 0) {
     return false;
   }
-  return G.cells.some((_, id) => isLegalMove(G, ctx, id));
+  return cardHasAnyLegalMove(G, ctx, G.deck[0]);
 }
 
 // Rotate the deck until the top card has a legal placement somewhere on the
@@ -141,11 +159,34 @@ export function ensurePlayableTopCard(G: GameState, ctx: Ctx): void {
   G.noValidMoves = true;
 }
 
-export function getInitialState(ctx: Ctx, random: RandomAPI): GameState {
+// Classic mode leaves the deck order alone, but still flags the dead end
+// where nothing in the deck can be placed, so endIf finishes the game
+// instead of forcing endless passes.
+export function checkForDeadEnd(G: GameState, ctx: Ctx): void {
+  if (!G.deck.some((card) => cardHasAnyLegalMove(G, ctx, card))) {
+    G.noValidMoves = true;
+  }
+}
+
+// Run whenever a new card surfaces at the top of the deck
+export function afterDeckChange(G: GameState, ctx: Ctx): void {
+  if (G.mode === "classic") {
+    checkForDeadEnd(G, ctx);
+  } else {
+    ensurePlayableTopCard(G, ctx);
+  }
+}
+
+export function getInitialState(
+  ctx: Ctx,
+  random: RandomAPI,
+  mode: GameMode
+): GameState {
   const G: GameState = {
     cells: [],
     deck: [],
     players: {},
+    mode,
   };
 
   // Add a deck for every player. Copy each card so G never holds the shared
@@ -175,7 +216,8 @@ export function getInitialState(ctx: Ctx, random: RandomAPI): GameState {
   const initialCard = { ...deck[random.Die(deck.length) - 1] };
   G.cells[center] = initialCard;
 
-  // Ensure the first card is playable
+  // Ensure the first card is playable (in both modes — classic always
+  // guaranteed the very first draw, with the rest left as shuffled)
   ensurePlayableTopCard(G, ctx);
 
   // For debugging "game over" state– this sets the deck to only have a single card
@@ -187,62 +229,64 @@ export function getInitialState(ctx: Ctx, random: RandomAPI): GameState {
   return G;
 }
 
-const game: Game<GameState> = {
-  // The setup method is passed the plugin context (ctx, random, …)
-  setup: ({ ctx, random }) => getInitialState(ctx, random),
+// The game is built per match so the chosen mode can be baked into setup —
+// App.tsx rebuilds the boardgame.io Client with createGame(mode) each game.
+export function createGame(mode: GameMode): Game<GameState> {
+  return {
+    // The setup method is passed the plugin context (ctx, random, …)
+    setup: ({ ctx, random }) => getInitialState(ctx, random, mode),
 
-  // End turn after a single move, whether it's placeCard or pass
-  turn: {
-    minMoves: 1,
-    maxMoves: 1,
-  },
-
-  moves: {
-    takeSnapshot: ({ G }) => {
-      console.log("==> takeSnapshot", G);
+    // End turn after a single move, whether it's placeCard or pass
+    turn: {
+      minMoves: 1,
+      maxMoves: 1,
     },
 
-    restoreSnapshot: ({ G }, id: keyof typeof snapshots) => {
-      if (id) {
-        return snapshots[id];
-      }
-    },
+    moves: {
+      takeSnapshot: ({ G }) => {
+        console.log("==> takeSnapshot", G);
+      },
 
-    // The { G, ctx } context is provided automatically when calling from App– `this.props.moves.placeCard(id)`
-    placeCard: ({ G, ctx }, id: number) => {
-      // Ensure we can't overwrite cells.
-      if (isLegalMove(G, ctx, id)) {
-        //Lay the card on the board
-        G.cells[id] = G.deck[0];
-        G.players[ctx.currentPlayer].score += calculateScore(G, ctx, id);
-
-        //Next card shifts up the deck
-        G.deck.shift();
-
-        if (G.deck.length > 0) {
-          ensurePlayableTopCard(G, ctx);
+      restoreSnapshot: ({ G }, id: keyof typeof snapshots) => {
+        if (id) {
+          return snapshots[id];
         }
+      },
+
+      // The { G, ctx } context is provided automatically when calling from App– `this.props.moves.placeCard(id)`
+      placeCard: ({ G, ctx }, id: number) => {
+        // Ensure we can't overwrite cells.
+        if (isLegalMove(G, ctx, id)) {
+          //Lay the card on the board
+          G.cells[id] = G.deck[0];
+          G.players[ctx.currentPlayer].score += calculateScore(G, ctx, id);
+
+          //Next card shifts up the deck
+          G.deck.shift();
+
+          if (G.deck.length > 0) {
+            afterDeckChange(G, ctx);
+          }
+        }
+      },
+
+      pass: ({ G, ctx }) => {
+        // Place top card to bottom of deck
+        G.deck.push(G.deck.shift()!);
+        afterDeckChange(G, ctx);
+      },
+    },
+
+    endIf: ({ G }) => {
+      if (G.deck.length === 0 || G.noValidMoves) {
+        const winner = Object.keys(G.players).reduce(
+          (previousPlayer, currentPlayer) =>
+            G.players[previousPlayer].score > G.players[currentPlayer].score
+              ? previousPlayer
+              : currentPlayer
+        );
+        return winner;
       }
     },
-
-    pass: ({ G, ctx }) => {
-      // Place top card to bottom of deck
-      G.deck.push(G.deck.shift()!);
-      ensurePlayableTopCard(G, ctx);
-    },
-  },
-
-  endIf: ({ G }) => {
-    if (G.deck.length === 0 || G.noValidMoves) {
-      const winner = Object.keys(G.players).reduce(
-        (previousPlayer, currentPlayer) =>
-          G.players[previousPlayer].score > G.players[currentPlayer].score
-            ? previousPlayer
-            : currentPlayer
-      );
-      return winner;
-    }
-  },
-};
-
-export default game;
+  };
+}

--- a/src/Matchimals/game.ts
+++ b/src/Matchimals/game.ts
@@ -121,6 +121,10 @@ export function isLegalMove(G: GameState, ctx: Ctx, id: number): boolean {
 }
 
 export function hasAnyLegalMove(G: GameState, ctx: Ctx): boolean {
+  // No card to play — isLegalMove reads G.deck[0], so guard the empty deck
+  if (G.deck.length === 0) {
+    return false;
+  }
   return G.cells.some((_, id) => isLegalMove(G, ctx, id));
 }
 

--- a/src/Matchimals/game.ts
+++ b/src/Matchimals/game.ts
@@ -10,17 +10,17 @@ export interface PlayerState {
   score: number;
 }
 
-// "kids": the deck always surfaces a playable card (and a dead deck ends the
+// "easy": the deck always surfaces a playable card (and a dead deck ends the
 // game). "classic": only the first card is guaranteed; unplayable cards are
 // PASSed, but a fully dead deck still ends the game instead of looping forever.
-export type GameMode = "kids" | "classic";
+export type GameMode = "easy" | "classic";
 
 export interface GameState {
   cells: (Card | null)[];
   deck: Card[];
   players: Record<string, PlayerState>;
   // Both optional so hardcoded snapshot states don't need to carry them;
-  // an undefined mode behaves as "kids"
+  // an undefined mode behaves as "easy"
   mode?: GameMode;
   noValidMoves?: boolean;
 }

--- a/src/Matchimals/game.ts
+++ b/src/Matchimals/game.ts
@@ -14,6 +14,8 @@ export interface GameState {
   cells: (Card | null)[];
   deck: Card[];
   players: Record<string, PlayerState>;
+  // Optional so hardcoded snapshot states don't need to carry it
+  noValidMoves?: boolean;
 }
 
 export interface Neighbors {
@@ -118,17 +120,21 @@ export function isLegalMove(G: GameState, ctx: Ctx, id: number): boolean {
   return false; //Return false if there are no neighboring cards that match
 }
 
-export function canCardsConnect(card1: Card, card2: Card): boolean {
-  if (
-    card1.top === card2.bottom ||
-    card1.bottom === card2.top ||
-    card1.left === card2.right ||
-    card1.right === card2.left
-  ) {
-    return true;
-  }
+export function hasAnyLegalMove(G: GameState, ctx: Ctx): boolean {
+  return G.cells.some((_, id) => isLegalMove(G, ctx, id));
+}
 
-  return false;
+// Rotate the deck until the top card has a legal placement somewhere on the
+// board, so every card that gets drawn is playable. If a full cycle through
+// the deck finds nothing, flag the dead end so endIf finishes the game.
+export function ensurePlayableTopCard(G: GameState, ctx: Ctx): void {
+  for (let i = 0; i < G.deck.length; i++) {
+    if (hasAnyLegalMove(G, ctx)) {
+      return;
+    }
+    G.deck.push(G.deck.shift()!); // Unplayable right now — try again later
+  }
+  G.noValidMoves = true;
 }
 
 export function getInitialState(ctx: Ctx, random: RandomAPI): GameState {
@@ -165,10 +171,8 @@ export function getInitialState(ctx: Ctx, random: RandomAPI): GameState {
   const initialCard = { ...deck[random.Die(deck.length) - 1] };
   G.cells[center] = initialCard;
 
-  // Ensure the first card is connectable
-  while (!canCardsConnect(G.deck[0], initialCard)) {
-    G.deck.push(G.deck.shift()!); // Place top card to bottom of deck, try again!
-  }
+  // Ensure the first card is playable
+  ensurePlayableTopCard(G, ctx);
 
   // For debugging "game over" state– this sets the deck to only have a single card
   // G.deck = new Array(G.deck[0]);
@@ -210,17 +214,22 @@ const game: Game<GameState> = {
 
         //Next card shifts up the deck
         G.deck.shift();
+
+        if (G.deck.length > 0) {
+          ensurePlayableTopCard(G, ctx);
+        }
       }
     },
 
-    pass: ({ G }) => {
+    pass: ({ G, ctx }) => {
       // Place top card to bottom of deck
       G.deck.push(G.deck.shift()!);
+      ensurePlayableTopCard(G, ctx);
     },
   },
 
   endIf: ({ G }) => {
-    if (G.deck.length === 0) {
+    if (G.deck.length === 0 || G.noValidMoves) {
       const winner = Object.keys(G.players).reduce(
         (previousPlayer, currentPlayer) =>
           G.players[previousPlayer].score > G.players[currentPlayer].score

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import type { ViewProps } from "react-native";
+import Reanimated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+
+import { colors } from "../constants/colors";
+
+const SEGMENT_WIDTH = 150;
+const SEGMENT_HEIGHT = 56;
+
+// A springy overshoot so the thumb lands with a playful bounce
+const SPRING = { damping: 14, stiffness: 220, mass: 1 };
+
+export interface ToggleOption<T extends string> {
+  label: string;
+  value: T;
+}
+
+interface ToggleProps<T extends string> extends ViewProps {
+  options: [ToggleOption<T>, ToggleOption<T>];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+const Toggle = <T extends string>({
+  options,
+  value,
+  onChange,
+  style,
+  ...rest
+}: ToggleProps<T>) => {
+  const activeIndex = options[1].value === value ? 1 : 0;
+
+  const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH);
+  const squash = useSharedValue(1);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    if (!mounted.current) {
+      // Snap into place on mount without animating
+      mounted.current = true;
+      translateX.value = activeIndex * SEGMENT_WIDTH;
+      return;
+    }
+    translateX.value = withSpring(activeIndex * SEGMENT_WIDTH, SPRING);
+    // Squash-and-stretch while the thumb slides over
+    squash.value = withSequence(
+      withTiming(0.8, { duration: 90 }),
+      withSpring(1, SPRING)
+    );
+  }, [activeIndex, translateX, squash]);
+
+  const thumbStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }, { scaleY: squash.value }],
+  }));
+
+  return (
+    <View style={[styles.track, style]} {...rest}>
+      <View style={styles.trackInner}>
+        <Reanimated.View style={[styles.thumb, thumbStyle]} />
+        {options.map((option) => (
+          <Pressable
+            key={option.value}
+            style={styles.segment}
+            onPress={() => onChange(option.value)}
+          >
+            <Text
+              style={[
+                styles.label,
+                option.value !== value && styles.labelInactive,
+              ]}
+            >
+              {option.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  track: {
+    backgroundColor: colors.blueLight,
+    borderRadius: 16,
+    borderWidth: 4,
+    borderColor: "#fff",
+  },
+  trackInner: {
+    flexDirection: "row",
+    borderWidth: 4,
+    borderColor: colors.grayDark,
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  thumb: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: SEGMENT_WIDTH,
+    backgroundColor: colors.yellowLight,
+    borderRadius: 8,
+    borderWidth: 3,
+    borderColor: colors.grayDark,
+  },
+  segment: {
+    width: SEGMENT_WIDTH,
+    height: SEGMENT_HEIGHT,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    fontFamily: "Dimbo",
+    fontSize: 26,
+    color: colors.grayDark,
+  },
+  labelInactive: {
+    opacity: 0.4,
+  },
+});
+
+export default Toggle;

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -12,6 +12,9 @@ import { colors } from "../constants/colors";
 
 const SEGMENT_WIDTH = 150;
 const SEGMENT_HEIGHT = 56;
+// The thumb is inset from the groove on all sides so the track shows around
+// it — it reads as a chip sitting in the groove rather than a full panel
+const THUMB_INSET = 5;
 
 // Quick ease-out slide — a clean toggle-switch feel, no overshoot
 const SLIDE = { duration: 220, easing: Easing.out(Easing.cubic) };
@@ -36,17 +39,20 @@ const Toggle = <T extends string>({
 }: ToggleProps<T>) => {
   const activeIndex = options[1].value === value ? 1 : 0;
 
-  const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH);
+  const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH + THUMB_INSET);
   const mounted = useRef(false);
 
   useEffect(() => {
     if (!mounted.current) {
       // Snap into place on mount without animating
       mounted.current = true;
-      translateX.value = activeIndex * SEGMENT_WIDTH;
+      translateX.value = activeIndex * SEGMENT_WIDTH + THUMB_INSET;
       return;
     }
-    translateX.value = withTiming(activeIndex * SEGMENT_WIDTH, SLIDE);
+    translateX.value = withTiming(
+      activeIndex * SEGMENT_WIDTH + THUMB_INSET,
+      SLIDE
+    );
   }, [activeIndex, translateX]);
 
   const thumbStyle = useAnimatedStyle(() => ({
@@ -110,20 +116,20 @@ const styles = StyleSheet.create({
   // the logo letters (no fuzzy shadows in this app).
   thumb: {
     position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: SEGMENT_WIDTH,
+    top: THUMB_INSET + 3,
+    bottom: THUMB_INSET,
+    width: SEGMENT_WIDTH - THUMB_INSET * 2,
     backgroundColor: colors.yellowDark,
-    borderRadius: 8,
+    borderRadius: 7,
   },
   thumbFace: {
     position: "absolute",
     top: 0,
     left: 0,
     right: 0,
-    bottom: 5,
+    bottom: 4,
     backgroundColor: colors.yellowLight,
-    borderRadius: 8,
+    borderRadius: 7,
   },
   segment: {
     width: SEGMENT_WIDTH,

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -56,6 +56,7 @@ const Toggle = <T extends string>({
   return (
     <View style={[styles.track, style]} {...rest}>
       <View style={styles.trackInner}>
+        <View style={styles.trackShadow} />
         <Reanimated.View style={[styles.thumb, thumbStyle]}>
           <View style={styles.thumbFace} />
         </Reanimated.View>
@@ -93,6 +94,16 @@ const styles = StyleSheet.create({
     borderColor: colors.grayDark,
     borderRadius: 12,
     overflow: "hidden",
+  },
+  // A hard dark band along the top inside of the groove makes the track read
+  // as recessed — the inverse of the thumb's bottom ledge, same top-light.
+  trackShadow: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 5,
+    backgroundColor: colors.blueGrayMedium,
   },
   // The thumb is a yellowDark base with the yellowLight face inset above it,
   // leaving a hard offset "ledge" at the bottom — the same cartoon depth as

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -56,7 +56,9 @@ const Toggle = <T extends string>({
   return (
     <View style={[styles.track, style]} {...rest}>
       <View style={styles.trackInner}>
-        <Reanimated.View style={[styles.thumb, thumbStyle]} />
+        <Reanimated.View style={[styles.thumb, thumbStyle]}>
+          <View style={styles.thumbFace} />
+        </Reanimated.View>
         {options.map((option) => (
           <Pressable
             key={option.value}
@@ -92,15 +94,25 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: "hidden",
   },
+  // The thumb is a yellowDark base with the yellowLight face inset above it,
+  // leaving a hard offset "ledge" at the bottom — the same cartoon depth as
+  // the logo letters (no fuzzy shadows in this app).
   thumb: {
     position: "absolute",
     top: 0,
     bottom: 0,
     width: SEGMENT_WIDTH,
+    backgroundColor: colors.yellowDark,
+    borderRadius: 8,
+  },
+  thumbFace: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 5,
     backgroundColor: colors.yellowLight,
     borderRadius: 8,
-    borderWidth: 3,
-    borderColor: colors.yellowDark,
   },
   segment: {
     width: SEGMENT_WIDTH,

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -79,17 +79,13 @@ const Toggle = <T extends string>({
 };
 
 const styles = StyleSheet.create({
-  // The control is flat inside; depth comes from a hard, blur-free drop
-  // shadow under the whole pill — the same cartoon offset the logo uses.
+  // Fully flat, like the rest of the app. If the app ever gets a hard
+  // "flat shadow" design pass, this pill is a natural candidate for one.
   track: {
     backgroundColor: colors.blueGrayLight,
     borderRadius: 16,
     borderWidth: 4,
     borderColor: "#fff",
-    shadowColor: colors.grayDark,
-    shadowOffset: { width: 0, height: 5 },
-    shadowOpacity: 0.3,
-    shadowRadius: 0,
   },
   trackInner: {
     flexDirection: "row",

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -5,7 +5,6 @@ import Reanimated, {
   Easing,
   useAnimatedStyle,
   useSharedValue,
-  withSequence,
   withTiming,
 } from "react-native-reanimated";
 
@@ -38,7 +37,6 @@ const Toggle = <T extends string>({
   const activeIndex = options[1].value === value ? 1 : 0;
 
   const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH);
-  const squash = useSharedValue(1);
   const mounted = useRef(false);
 
   useEffect(() => {
@@ -49,15 +47,10 @@ const Toggle = <T extends string>({
       return;
     }
     translateX.value = withTiming(activeIndex * SEGMENT_WIDTH, SLIDE);
-    // A subtle squash while the thumb slides, recovering smoothly
-    squash.value = withSequence(
-      withTiming(0.85, { duration: 90, easing: Easing.in(Easing.quad) }),
-      withTiming(1, { duration: 130, easing: Easing.out(Easing.quad) })
-    );
-  }, [activeIndex, translateX, squash]);
+  }, [activeIndex, translateX]);
 
   const thumbStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }, { scaleY: squash.value }],
+    transform: [{ translateX: translateX.value }],
   }));
 
   return (

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -107,7 +107,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.yellowLight,
     borderRadius: 8,
     borderWidth: 3,
-    borderColor: colors.grayDark,
+    borderColor: colors.yellowDark,
   },
   segment: {
     width: SEGMENT_WIDTH,

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useRef } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import type { ViewProps } from "react-native";
 import Reanimated, {
+  Easing,
   useAnimatedStyle,
   useSharedValue,
   withSequence,
-  withSpring,
   withTiming,
 } from "react-native-reanimated";
 
@@ -14,8 +14,8 @@ import { colors } from "../constants/colors";
 const SEGMENT_WIDTH = 150;
 const SEGMENT_HEIGHT = 56;
 
-// A springy overshoot so the thumb lands with a playful bounce
-const SPRING = { damping: 14, stiffness: 220, mass: 1 };
+// Quick ease-out slide — a clean toggle-switch feel, no overshoot
+const SLIDE = { duration: 220, easing: Easing.out(Easing.cubic) };
 
 export interface ToggleOption<T extends string> {
   label: string;
@@ -48,11 +48,11 @@ const Toggle = <T extends string>({
       translateX.value = activeIndex * SEGMENT_WIDTH;
       return;
     }
-    translateX.value = withSpring(activeIndex * SEGMENT_WIDTH, SPRING);
-    // Squash-and-stretch while the thumb slides over
+    translateX.value = withTiming(activeIndex * SEGMENT_WIDTH, SLIDE);
+    // A subtle squash while the thumb slides, recovering smoothly
     squash.value = withSequence(
-      withTiming(0.8, { duration: 90 }),
-      withSpring(1, SPRING)
+      withTiming(0.85, { duration: 90, easing: Easing.in(Easing.quad) }),
+      withTiming(1, { duration: 130, easing: Easing.out(Easing.quad) })
     );
   }, [activeIndex, translateX, squash]);
 

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -12,9 +12,6 @@ import { colors } from "../constants/colors";
 
 const SEGMENT_WIDTH = 150;
 const SEGMENT_HEIGHT = 56;
-// The thumb is inset from the groove on all sides so the track shows around
-// it — it reads as a chip sitting in the groove rather than a full panel
-const THUMB_INSET = 5;
 
 // Quick ease-out slide — a clean toggle-switch feel, no overshoot
 const SLIDE = { duration: 220, easing: Easing.out(Easing.cubic) };
@@ -39,20 +36,17 @@ const Toggle = <T extends string>({
 }: ToggleProps<T>) => {
   const activeIndex = options[1].value === value ? 1 : 0;
 
-  const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH + THUMB_INSET);
+  const translateX = useSharedValue(activeIndex * SEGMENT_WIDTH);
   const mounted = useRef(false);
 
   useEffect(() => {
     if (!mounted.current) {
       // Snap into place on mount without animating
       mounted.current = true;
-      translateX.value = activeIndex * SEGMENT_WIDTH + THUMB_INSET;
+      translateX.value = activeIndex * SEGMENT_WIDTH;
       return;
     }
-    translateX.value = withTiming(
-      activeIndex * SEGMENT_WIDTH + THUMB_INSET,
-      SLIDE
-    );
+    translateX.value = withTiming(activeIndex * SEGMENT_WIDTH, SLIDE);
   }, [activeIndex, translateX]);
 
   const thumbStyle = useAnimatedStyle(() => ({
@@ -62,10 +56,7 @@ const Toggle = <T extends string>({
   return (
     <View style={[styles.track, style]} {...rest}>
       <View style={styles.trackInner}>
-        <View style={styles.trackShadow} />
-        <Reanimated.View style={[styles.thumb, thumbStyle]}>
-          <View style={styles.thumbFace} />
-        </Reanimated.View>
+        <Reanimated.View style={[styles.thumb, thumbStyle]} />
         {options.map((option) => (
           <Pressable
             key={option.value}
@@ -88,11 +79,17 @@ const Toggle = <T extends string>({
 };
 
 const styles = StyleSheet.create({
+  // The control is flat inside; depth comes from a hard, blur-free drop
+  // shadow under the whole pill — the same cartoon offset the logo uses.
   track: {
     backgroundColor: colors.blueGrayLight,
     borderRadius: 16,
     borderWidth: 4,
     borderColor: "#fff",
+    shadowColor: colors.grayDark,
+    shadowOffset: { width: 0, height: 5 },
+    shadowOpacity: 0.3,
+    shadowRadius: 0,
   },
   trackInner: {
     flexDirection: "row",
@@ -101,35 +98,15 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     overflow: "hidden",
   },
-  // A hard dark band along the top inside of the groove makes the track read
-  // as recessed — the inverse of the thumb's bottom ledge, same top-light.
-  trackShadow: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 5,
-    backgroundColor: colors.blueGrayMedium,
-  },
-  // The thumb is a yellowDark base with the yellowLight face inset above it,
-  // leaving a hard offset "ledge" at the bottom — the same cartoon depth as
-  // the logo letters (no fuzzy shadows in this app).
   thumb: {
     position: "absolute",
-    top: THUMB_INSET + 3,
-    bottom: THUMB_INSET,
-    width: SEGMENT_WIDTH - THUMB_INSET * 2,
-    backgroundColor: colors.yellowDark,
-    borderRadius: 7,
-  },
-  thumbFace: {
-    position: "absolute",
     top: 0,
-    left: 0,
-    right: 0,
-    bottom: 4,
+    bottom: 0,
+    width: SEGMENT_WIDTH,
     backgroundColor: colors.yellowLight,
-    borderRadius: 7,
+    borderRadius: 8,
+    borderWidth: 3,
+    borderColor: colors.yellowDark,
   },
   segment: {
     width: SEGMENT_WIDTH,

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -80,7 +80,7 @@ const Toggle = <T extends string>({
 
 const styles = StyleSheet.create({
   track: {
-    backgroundColor: colors.blueLight,
+    backgroundColor: colors.blueGrayLight,
     borderRadius: 16,
     borderWidth: 4,
     borderColor: "#fff",

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -7,6 +7,7 @@ export const colors = {
   greenLight: "#CAE1C3",
   greenMedium: "#7A9572",
   blueLight: "#C5E5F0",
+  blueGrayLight: "#DAE4E9",
   blueMedium: "#7698A4",
   blueDark: "#364F57",
   purpleMedium: "#94638D",

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -3,6 +3,7 @@ export const colors = {
   redMedium: "#DB7270",
   orangeMedium: "#CD7547",
   yellowLight: "#FFEA87",
+  yellowDark: "#D6B845",
   greenLight: "#CAE1C3",
   greenMedium: "#7A9572",
   blueLight: "#C5E5F0",

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -8,6 +8,7 @@ export const colors = {
   greenMedium: "#7A9572",
   blueLight: "#C5E5F0",
   blueGrayLight: "#DAE4E9",
+  blueGrayMedium: "#B9C6CD",
   blueMedium: "#7698A4",
   blueDark: "#364F57",
   purpleMedium: "#94638D",

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -8,7 +8,6 @@ export const colors = {
   greenMedium: "#7A9572",
   blueLight: "#C5E5F0",
   blueGrayLight: "#DAE4E9",
-  blueGrayMedium: "#B9C6CD",
   blueMedium: "#7698A4",
   blueDark: "#364F57",
   purpleMedium: "#94638D",


### PR DESCRIPTION
## What this does

Adds a game mode setting with two modes, picked on the main menu via a new animated segmented toggle:

- **Easy Mode** (default): the deck always surfaces a card that has at least one legal placement on the current board. Under the hood, after setup and after every `placeCard`/`pass`, the deck rotates until the top card passes a strict position-aware playability check (`isLegalMove` scanned across all cells — all touching neighbors must match, not just one edge). Only the unplayable prefix rotates, so the rest of the deck stays as shuffled.
- **Classic**: the original rules — the first card is guaranteed at setup (as before), the deck otherwise plays out exactly as shuffled, and unplayable cards are PASSed. One improvement over the true original: a fully dead deck (no remaining card placeable anywhere) is now detected without reordering anything.

In **both modes**, a dead end sets `G.noValidMoves` and `endIf` finishes the game with the highest score winning — previously the game could only end when the deck emptied, so a dead board meant passing forever.

## How it's wired

- `src/Matchimals/game.ts`: `GameMode` type; `createGame(mode)` factory (the boardgame.io Client is already rebuilt per game in `App.tsx`, so the mode is baked into `setup`); mode stored on `GameState` (optional — `undefined` behaves as easy, keeping the dev snapshots valid); `afterDeckChange` branches per mode; `isLegalMove` gains an optional card param so the Classic dead-end scan can test any deck card; `hasAnyLegalMove` guards the empty deck.
- `src/App.tsx`: mode state, hydrated from AsyncStorage (`gameMode` key) on mount and persisted on change; defaults to easy.
- `src/Toggle/`: new reusable animated segmented toggle (Reanimated ease-out slide, no bounce), styled to match the existing button chrome, fully flat per the current design language.
- `src/MainMenu/`: the toggle plus a one-line caption under it that swaps with the selection and fades in ("Always a match to make" / "Match if you can, pass if not").
- `canCardsConnect` (the old loose one-side check used only for the initial card) is removed; setup now uses the same strict check as everything else.

## How to test

1. `bun install && bun run web` (or `bun run ios`).
2. Main menu: EASY MODE should be selected by default; tap CLASSIC and back — the thumb slides, the caption swaps.
3. Start a game in Easy Mode: the face-up card always has a legal spot somewhere (it can still take some finding — that's the puzzle). PASS still works as a strategic skip.
4. Start a game in Classic: draws come as shuffled; unplayable cards must be passed.
5. Kill and relaunch: the last-chosen mode is preselected.
6. End-of-game: play a deck out (or temporarily re-enable the single-card debug line in `getInitialState`) — the Victory screen appears when the deck empties or dead-ends in either mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)