### PR TITLE
fix: make card drag, pan, and pinch-zoom work on mobile web

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="shortcut icon" href="/icons/favicon.png" />
-    <link
-      rel="apple-touch-icon"
-      href="/icons/apple-touch-icon-60x60.png"
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
+    <link rel="shortcut icon" href="/icons/favicon.png" />
+    <link rel="apple-touch-icon" href="/icons/apple-touch-icon-60x60.png" />
     <link
       rel="apple-touch-icon"
       sizes="120x120"
@@ -43,10 +43,7 @@
       property="og:description"
       content="Matchimals is a simple card game in which two players take turns trying to match animals in a puzzle-like fashion. The player with the most points at the end wins!"
     />
-    <meta
-      property="og:image"
-      content="/matchimals-og-1200x630.png"
-    />
+    <meta property="og:image" content="/matchimals-og-1200x630.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary" />
@@ -58,10 +55,7 @@
       name="twitter:description"
       content="Matchimals is a simple card game in which two players take turns trying to match animals in a puzzle-like fashion. The player with the most points at the end wins!"
     />
-    <meta
-      name="twitter:image"
-      content="/matchimals-og-600x600.png"
-    />
+    <meta name="twitter:image" content="/matchimals-og-600x600.png" />
     <title>Matchimals- an animal matching puzzle card game 🦁 🃏</title>
     <style>
       @font-face {
@@ -77,6 +71,32 @@
         -moz-user-select: none; /* Firefox all */
         -ms-user-select: none; /* IE 10+ */
         user-select: none; /* Likely future */
+        -webkit-touch-callout: none; /* no long-press callout on card images (iOS) */
+      }
+      /* Full-screen game: the page must never scroll. On mobile Safari/Chrome
+         the URL bar makes a 100vh page overflow, and any page scroll (or
+         rubber-band overscroll, which ignores touch-action) fires pointercancel
+         mid-drag and snaps the card back to the deck. Pinning body with
+         position: fixed is the iOS-proof way to kill document scrolling;
+         inner ScrollViews (e.g. the rules dialog) still scroll normally. */
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        overscroll-behavior: none;
+      }
+      body {
+        position: fixed;
+        inset: 0;
+        width: 100%;
+      }
+      /* Track the live viewport (URL bar collapse/expand) in every browser,
+         and give the RNW flex chain a definite size to fill. */
+      #root {
+        position: fixed;
+        inset: 0;
+        display: flex;
       }
     </style>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import { Platform, StatusBar, StyleSheet, View } from "react-native";
+import { StatusBar, StyleSheet, View } from "react-native";
 import { useAsyncStorage } from "@react-native-async-storage/async-storage";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -114,8 +114,10 @@ const styles = StyleSheet.create({
   root: {
     position: "relative",
     width: "100%",
-    // react-native-web supports viewport units; RN's style types don't.
-    height: Platform.OS === "web" ? ("100vh" as unknown as number) : "100%",
+    // On web this fills #root, which index.html pins to the live viewport
+    // (position: fixed; inset: 0) — unlike 100vh, it tracks the mobile URL bar
+    // collapsing/expanding, so the deck and buttons stay on screen.
+    height: "100%",
     overflow: "hidden",
     backgroundColor: colors.grayDark,
   },

--- a/src/Dialog/index.web.tsx
+++ b/src/Dialog/index.web.tsx
@@ -40,8 +40,9 @@ const Dialog = ({
             contentContainerStyle={{
               paddingTop: 60,
               // react-native-web supports CSS calc() strings; RN's style types
-              // don't know about them.
-              maxHeight: "calc(100vh - 120px)" as unknown as number,
+              // don't know about them. dvh (not vh) so the cap tracks the
+              // visible viewport when the mobile URL bar is expanded.
+              maxHeight: "calc(100dvh - 120px)" as unknown as number,
             }}
           >
             {children}


### PR DESCRIPTION
## Problem

On iOS (Safari and Chrome — both WebKit), dragging a card from the deck on matchimals.fun barely worked: the drag would start, the screen would immediately scroll up/down, and the card would snap back to the deck.

## Root cause

The card's gesture was fine — react-native-gesture-handler already applies `touch-action: none` to the card element on web. The page itself was the problem:

- The app root was `100vh` inside a default-scrollable `html/body`. On mobile, the URL bar makes the visible viewport shorter than `100vh`, so the document overflows and can scroll.
- iOS additionally allows rubber-band scrolling of the document even where `touch-action` forbids it (long-standing WebKit behavior at the document level).

So mid-drag, WebKit would reinterpret the finger movement as a page scroll, scroll the document (the up/down jump), and fire `pointercancel`. RNGH finalized the gesture as failed and the card reset to the deck.

## Fix

- **`public/index.html`** — standard full-screen-game scroll lock: `overflow: hidden` + `overscroll-behavior: none` on `html/body`, and `position: fixed` on `body` (the iOS-proof way to kill document scrolling/rubber-banding). `#root` is pinned with `position: fixed; inset: 0` so it tracks the live viewport as the URL bar collapses. Viewport meta gains `maximum-scale=1, user-scalable=no, viewport-fit=cover` so page pinch-zoom doesn't fight the board's own pinch gesture, and `-webkit-touch-callout: none` stops the long-press image callout on cards.
- **`src/App.tsx`** — root height `100vh` → `100%` (fills the pinned `#root`). Also fixes the deck/PASS button sitting partly below the visible area when the URL bar was expanded, since `100vh` is the *largest* viewport on iOS. Behavioral no-op on native (it was already `100%` there).
- **`src/Dialog/index.web.tsx`** — dialog height cap `calc(100vh - 120px)` → `calc(100dvh - 120px)` so the rules dialog fits the visible mobile viewport. Inner ScrollViews still scroll normally; the lock only affects the document.

## Manual test steps

1. `bun run web`, then open `http://<mac-ip>:8081` on an iPhone (same Wi-Fi) in Safari and Chrome.
2. Drag a card from the deck onto the board — it should follow your finger with no page scroll and drop on the aimed cell.
3. Pan the board with one finger and pinch-zoom with two — no page zoom or rubber-banding.
4. Open the ? menu / rules dialog — it fits on screen and its content still scrolls.
5. Desktop web at localhost:8081 — drag/pan/zoom unchanged.

✅ Verified on iPhone (Safari + Chrome) by Chris — drag, pan, and pinch-zoom all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)