### PR TITLE
feat: one-command local TestFlight deploy (bun run deploy:ios)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# App Store Connect API key (for scripts/deploy-ios.sh)
+# The key file lives at ~/.appstoreconnect/private_keys/AuthKey_<ASC_KEY_ID>.p8
+ASC_KEY_ID=
+ASC_ISSUER_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Expo / generated native project (CNG — regenerate with `bun run prebuild`)
 /ios/
+/build/
 .expo/
 /dist/
 *.jsbundle

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # OSX
 .DS_Store
 
+# Claude Code local state (session permissions, worktrees)
+.claude/
+
 # Expo / generated native project (CNG — regenerate with `bun run prebuild`)
 /ios/
 /build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ bun run format         # prettier on src/**
 
 bun run prebuild       # regenerate ios/ from app.json (expo prebuild -p ios --clean)
 bun run build:web      # static web export to dist/ (expo export -p web)
+bun run deploy:ios     # bump build number, archive, and upload to TestFlight (scripts/deploy-ios.sh)
 ```
 
 Run a single test: `bun run test -- path/to/file.test.js` (or `-t "name"`). There is currently no test suite, so `test` passes with no tests.
@@ -27,7 +28,7 @@ Lint: `.eslintrc` extends `@react-native`; `lint-staged` runs prettier on commit
 
 ## Continuous native generation
 
-The `ios/` directory is **generated** from `app.json` (and the config plugins) — it is not the source of truth and is gitignored. Never hand-edit native iOS files expecting changes to persist; edit `app.json` or a config plugin and re-run `bun run prebuild`. Building requires Xcode + CocoaPods. Releases are built locally (no paid EAS): bump `version`/`ios.buildNumber` in `app.json`, then archive in Xcode or `bunx eas build -p ios --local`. See the build-philosophy memory: no fastlane, no paid EAS.
+The `ios/` directory is **generated** from `app.json` (and the config plugins) — it is not the source of truth and is gitignored. Never hand-edit native iOS files expecting changes to persist; edit `app.json` or a config plugin and re-run `bun run prebuild`. Building requires Xcode + CocoaPods. Releases are built locally (no paid EAS): `bun run deploy:ios` auto-increments `ios.buildNumber`, archives, and uploads to TestFlight (needs an App Store Connect API key — see README "Deploying to TestFlight"); bump `version` in `app.json` manually for new releases. See the build-philosophy memory: no fastlane, no paid EAS.
 
 `plugins/withFirebaseNoAdId.js` is a custom dangerous-mod plugin that prepends `$RNFirebaseAnalyticsWithoutAdIdSupport=true` to the Podfile so AdSupport.framework isn't linked (keeps the App Store privacy declaration clean).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ The `ios/` directory is **generated** from `app.json` (and the config plugins) �
 
 ## Conventions
 
+- **This is a public GitHub repo.** Before every commit, review the diff for anything private — credentials, API key IDs, tokens, personal info, internal URLs. Secrets belong only in `.env` (gitignored) and `~/.appstoreconnect/`; never in tracked files, commit messages, or PR descriptions.
 - Prettier (default config, `.prettierrc`) — let `bun run format` handle style; don't hand-format.
 - Components are folders with an `index.tsx`; assets (png/jpg/svg/mp4) live beside the component that uses them. Asset imports are declared in `src/declarations.d.ts`.
 - TypeScript is strict (`tsconfig.json` extends Expo's base + `"strict": true`); run `bun run typecheck` before committing. Prefer narrow local types over `any`; the deliberate escape hatches (e.g. web-only CSS values cast past RN's style types) carry comments.

--- a/README.md
+++ b/README.md
@@ -42,14 +42,23 @@ This is an [Expo](https://expo.dev) app using [continuous native generation](htt
 1.  Build and run the app in the iOS simulator: `bun run ios`
 1.  Or run the web version: `bun run web`
 
-### Releasing
+### Deploying to TestFlight
 
-Releases are built locally (no EAS subscription required). Bump `version`/`ios.buildNumber` in `app.json`, then either:
+iOS releases are built and uploaded entirely locally (no EAS subscription or fastlane required):
 
-- **Xcode:** `bun run prebuild`, then `open ios/Matchimals.xcworkspace` → Product → Archive → Distribute, or
-- **EAS local build:** `bunx eas build -p ios --local` (free; requires an Expo account)
+```bash
+bun run deploy:ios
+```
 
-The web version is exported with `bun run build:web` (static output in `dist/`).
+The script (`scripts/deploy-ios.sh`) auto-increments `ios.buildNumber` in `app.json` (and commits the bump), runs `expo prebuild`, archives with `xcodebuild`, uploads the build straight to App Store Connect, and tags the commit (`ios-v<version>-<build>`). It refuses to run unless you're on a clean `main` and the typecheck passes. App version bumps (`expo.version`) are still manual — edit `app.json` before deploying a new release.
+
+One-time setup (credentials never leave your machine — nothing secret is committed):
+
+1. In [App Store Connect](https://appstoreconnect.apple.com) → Users and Access → Integrations → App Store Connect API, generate a **Team key** with the **App Manager** role. Note the Key ID and Issuer ID.
+2. `mkdir -p ~/.appstoreconnect/private_keys` and move the downloaded `AuthKey_<KEYID>.p8` there.
+3. `cp .env.example .env` and fill in `ASC_KEY_ID` and `ASC_ISSUER_ID`.
+
+The web version deploys automatically via Netlify when `main` is pushed (`bun run build:web` for a local static export to `dist/`).
 
 ## Special thanks
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prebuild": "expo prebuild -p ios --clean",
     "web": "expo start --web",
     "build:web": "expo export -p web",
+    "deploy:ios": "./scripts/deploy-ios.sh",
     "test": "jest --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write 'src/**/*.{ts,tsx,js,json,md}'"

--- a/scripts/deploy-ios.sh
+++ b/scripts/deploy-ios.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Deploy the iOS app to TestFlight, entirely on this machine.
+#
+#   bun run deploy:ios
+#
+# Pipeline: guardrails → bump ios.buildNumber in app.json (+ commit) →
+# expo prebuild → xcodebuild archive → xcodebuild -exportArchive with
+# destination:upload (sends the build to App Store Connect) → git tag.
+#
+# One-time setup is described in the README ("Deploying to TestFlight").
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+err() {
+  echo "✖ $1" >&2
+  exit 1
+}
+
+setup_help() {
+  cat >&2 <<'EOF'
+✖ Missing App Store Connect credentials. One-time setup:
+
+  1. App Store Connect → Users and Access → Integrations → App Store Connect API
+     → generate a Team key with the "App Manager" role.
+     Note the Key ID and Issuer ID.
+  2. mkdir -p ~/.appstoreconnect/private_keys
+     and move the downloaded AuthKey_<KEYID>.p8 there.
+  3. cp .env.example .env
+     and fill in ASC_KEY_ID and ASC_ISSUER_ID.
+EOF
+  exit 1
+}
+
+# --- Guardrails --------------------------------------------------------------
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+[[ "$branch" == "main" ]] || err "Deploys must run from main (currently on '$branch')."
+[[ -z "$(git status --porcelain)" ]] || err "Working tree is dirty — commit or stash first."
+
+echo "▸ Typechecking…"
+bun run typecheck
+
+# --- Credentials -------------------------------------------------------------
+
+[[ -f .env ]] || setup_help
+set -a
+source .env
+set +a
+[[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" ]] || setup_help
+
+ASC_KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+[[ -f "$ASC_KEY_PATH" ]] || setup_help
+
+# --- Bump build number (app.json is the CNG source of truth) -----------------
+
+BUILD_NUMBER=$(bun -e '
+  const file = "app.json";
+  const json = await Bun.file(file).json();
+  const next = String(Number(json.expo.ios.buildNumber) + 1);
+  json.expo.ios.buildNumber = next;
+  await Bun.write(file, JSON.stringify(json, null, 2) + "\n");
+  console.log(next);
+')
+VERSION=$(bun -e 'console.log((await Bun.file("app.json").json()).expo.version)')
+TEAM_ID=$(bun -e 'console.log((await Bun.file("app.json").json()).expo.ios.appleTeamId)')
+
+echo "▸ Deploying Matchimals ${VERSION} (build ${BUILD_NUMBER})"
+git add app.json
+git commit -m "chore: bump iOS build number to ${BUILD_NUMBER}"
+
+# --- Prebuild (regenerates ios/ from app.json) --------------------------------
+
+echo "▸ Prebuilding…"
+bun run prebuild
+
+# --- Archive ------------------------------------------------------------------
+
+ARCHIVE_PATH="build/Matchimals.xcarchive"
+rm -rf "$ARCHIVE_PATH"
+
+echo "▸ Archiving (this takes a while)…"
+xcodebuild -workspace ios/Matchimals.xcworkspace \
+  -scheme Matchimals \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath "$ARCHIVE_PATH" \
+  archive \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "$ASC_KEY_PATH" \
+  -authenticationKeyID "$ASC_KEY_ID" \
+  -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+# --- Export & upload to App Store Connect ------------------------------------
+
+cat > build/ExportOptions.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store-connect</string>
+  <key>destination</key>
+  <string>upload</string>
+  <key>teamID</key>
+  <string>${TEAM_ID}</string>
+  <key>signingStyle</key>
+  <string>automatic</string>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>manageAppVersionAndBuildNumber</key>
+  <false/>
+</dict>
+</plist>
+EOF
+
+echo "▸ Uploading to App Store Connect…"
+xcodebuild -exportArchive \
+  -archivePath "$ARCHIVE_PATH" \
+  -exportOptionsPlist build/ExportOptions.plist \
+  -exportPath build/export \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "$ASC_KEY_PATH" \
+  -authenticationKeyID "$ASC_KEY_ID" \
+  -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+# --- Tag ----------------------------------------------------------------------
+
+TAG="ios-v${VERSION}-${BUILD_NUMBER}"
+git tag "$TAG"
+
+echo "✔ Uploaded build ${BUILD_NUMBER} — it will appear in TestFlight once Apple finishes processing."
+echo "  Tagged ${TAG}. Don't forget: git push --follow-tags"


### PR DESCRIPTION
## What

Adds `bun run deploy:ios` — a single command that ships an iOS build to TestFlight entirely from this machine (no fastlane, no paid EAS).

`scripts/deploy-ios.sh` pipeline:

1. **Guardrails** — refuses unless on a clean `main`; runs `bun run typecheck`.
2. **Credentials check** — needs `ASC_KEY_ID` / `ASC_ISSUER_ID` in `.env` and the matching `AuthKey_<KEYID>.p8` in `~/.appstoreconnect/private_keys/` (prints one-time setup instructions if missing).
3. **Build number bump** — auto-increments `ios.buildNumber` in `app.json` and commits the bump (app.json is the CNG source of truth).
4. **Build & upload** — `expo prebuild`, `xcodebuild archive`, then `xcodebuild -exportArchive` with `destination: upload` straight to App Store Connect.
5. **Tag** — `ios-v<version>-<build>`.

Also:

- `.env.example` documents the two required variables (values stay local; `.env` is gitignored).
- README gains a "Deploying to TestFlight" section with the one-time App Store Connect API key setup.
- `.claude/` gitignored so machine-local Claude Code state doesn't trip the clean-tree guardrail.
- CLAUDE.md: notes the new command, and adds a convention to review every diff for secrets since this repo is public.

## Privacy check

Audited before pushing: no credentials or key IDs in any tracked file — only the empty-valued `.env.example`. (`appleTeamId` in `app.json` is pre-existing and not secret; it's embedded in every published binary.)

## How to test

1. `git checkout main && git pull` after merging.
2. `bun run deploy:ios` — should typecheck, bump the build number, archive (~a few minutes), and upload.
3. Watch for the build to appear in App Store Connect → TestFlight after Apple's processing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)