### PR TITLE
design: legible mode caption + compact main menu on small screens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
       href="/icons/apple-touch-icon-180x180.png"
     />
     <meta name="apple-mobile-web-app-title" content="Matchimals" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="#1e1412" />
     <meta name="theme-color" content="#1e1412" />

--- a/src/Card/CardFront.tsx
+++ b/src/Card/CardFront.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
-import type { StyleProp, ViewStyle } from "react-native";
+import { Platform, StyleSheet, Text, View } from "react-native";
+import type { StyleProp, TextStyle, ViewStyle } from "react-native";
 import Svg, { Polygon } from "svgs";
 
 import { animals } from "../constants/animals";
@@ -132,12 +132,20 @@ const styles = StyleSheet.create({
     fontSize: animalSize * 0.21875,
     fontWeight: "700",
     textAlign: "center",
-    textShadowColor: "rgba(0,0,0,0.69)",
-    textShadowRadius: 0,
-    textShadowOffset: {
-      width: 1,
-      height: 1,
-    },
+    // react-native-web deprecated the textShadow* long-form props in favor
+    // of the CSS shorthand, which native RN doesn't support yet — so each
+    // platform gets its own form (the shorthand is cast past RN's types)
+    ...Platform.select({
+      web: { textShadow: "1px 1px 0 rgba(0,0,0,0.69)" } as unknown as TextStyle,
+      default: {
+        textShadowColor: "rgba(0,0,0,0.69)",
+        textShadowRadius: 0,
+        textShadowOffset: {
+          width: 1,
+          height: 1,
+        },
+      },
+    }),
   },
 });
 

--- a/src/MainMenu/index.tsx
+++ b/src/MainMenu/index.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect } from "react";
-import { ImageBackground, StyleSheet, Text, View } from "react-native";
+import {
+  ImageBackground,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Reanimated, {
   useAnimatedStyle,
@@ -30,6 +36,10 @@ const Menu = ({
   setGameMode: (mode: GameMode) => void;
 }) => {
   const insets = useSafeAreaInsets();
+  const { width, height } = useWindowDimensions();
+  // On phone-sized viewports the full column collides with the
+  // bottom-right audio controls, so tighten the top of the column
+  const compact = width < 500 || height < 700;
 
   // Fade the caption back in whenever the mode (and its text) changes
   const captionOpacity = useSharedValue(0);
@@ -45,8 +55,14 @@ const Menu = ({
   return (
     <ImageBackground source={TriangleBackground} style={styles.root}>
       <>
-        <Logo width={306} height={60} style={{ marginBottom: 48 }} />
-        <Text style={styles.text}>HOW MANY PLAYERS?</Text>
+        <Logo
+          width={compact ? 224 : 306}
+          height={compact ? 44 : 60}
+          style={{ marginBottom: compact ? 20 : 48 }}
+        />
+        <Text style={[styles.text, compact && styles.textCompact]}>
+          HOW MANY PLAYERS?
+        </Text>
         <View
           style={{
             width: 280,
@@ -91,9 +107,15 @@ const Menu = ({
           ]}
           value={gameMode}
           onChange={setGameMode}
-          style={{ marginTop: 24 }}
+          style={{ marginTop: compact ? 16 : 24 }}
         />
-        <Reanimated.Text style={[styles.caption, captionStyle]}>
+        <Reanimated.Text
+          style={[
+            styles.caption,
+            compact && styles.captionCompact,
+            captionStyle,
+          ]}
+        >
           {modeCaptions[gameMode]}
         </Reanimated.Text>
 
@@ -115,12 +137,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  button: {
-    marginBottom: 8,
-  },
-  active: {
-    borderColor: "blue",
-  },
   text: {
     color: colors.grayDark,
     fontFamily: "Dimbo",
@@ -128,9 +144,14 @@ const styles = StyleSheet.create({
     lineHeight: 60,
     marginBottom: 32,
   },
+  textCompact: {
+    fontSize: 32,
+    lineHeight: 40,
+    marginBottom: 16,
+  },
   caption: {
-    // Muted vs the heading — the animated fade owns the opacity prop
-    color: colors.grayMedium,
+    // The animated fade owns the opacity prop
+    color: colors.grayDark,
     fontFamily: "Dimbo",
     fontSize: 22,
     lineHeight: 28,
@@ -139,6 +160,9 @@ const styles = StyleSheet.create({
     // Both captions are single-line; fixed height keeps the layout stable
     height: 28,
     textAlign: "center",
+  },
+  captionCompact: {
+    marginTop: 8,
   },
 });
 

--- a/src/Overlay/index.tsx
+++ b/src/Overlay/index.tsx
@@ -37,13 +37,28 @@ const OverlayHost = () => {
   }, []);
 
   return (
-    <View style={[StyleSheet.absoluteFill, { pointerEvents: "box-none" }]}>
+    <View style={styles.host}>
       {Object.entries(overlays).map(([id, node]) => (
         <Fragment key={id}>{node}</Fragment>
       ))}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  host: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    // Must live in StyleSheet.create, not an inline style object:
+    // react-native-web can only express "box-none" as a generated CSS
+    // class (none on the host, auto on children) — inlined, the invalid
+    // declaration is dropped and the host swallows every click
+    pointerEvents: "box-none",
+  },
+});
 
 // Renders the host alongside the app. No React state here, so it never forces
 // the app subtree to re-render.

--- a/src/Overlay/index.tsx
+++ b/src/Overlay/index.tsx
@@ -37,7 +37,7 @@ const OverlayHost = () => {
   }, []);
 
   return (
-    <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+    <View style={[StyleSheet.absoluteFill, { pointerEvents: "box-none" }]}>
       {Object.entries(overlays).map(([id, node]) => (
         <Fragment key={id}>{node}</Fragment>
       ))}


### PR DESCRIPTION
## What

Pre-ship design fixes on the main menu, plus cleanup of the dev-console deprecation warnings on web.

### Main menu (`src/MainMenu/index.tsx`)
- The mode-switch caption ("Always a match to make" / "Match if you can, pass if not") now uses the same near-black as the "HOW MANY PLAYERS?" heading (`colors.grayDark`) instead of grey, so it's legible.
- **Compact layout on phone-sized viewports** (window < 500px wide or < 700px tall, via `useWindowDimensions`): smaller logo (224×44), smaller heading (32/40), and tighter vertical margins. This shortens the centered column ~95px so the bottom-right music/sound buttons no longer overlap the mode switcher and caption on mobile. Player buttons and the toggle keep their sizes; desktop/iPad layout is unchanged.
- Removed two unused style entries (`button`, `active`).

### Console deprecation warnings (web)
- `textShadow*` props: the card score text (`src/Card/CardFront.tsx`) now uses the CSS `textShadow` shorthand on web (react-native-web deprecated the long-form props) and keeps the long-form props on native, which doesn't support the shorthand yet. Visually identical.
- `props.pointerEvents`: the overlay host (`src/Overlay/index.tsx`) moves `pointerEvents: "box-none"` from prop to style. **Note:** it must live in `StyleSheet.create`, not an inline style object — react-native-web can only express `box-none` as a generated CSS class, and the inline form silently drops it, which briefly made the full-screen overlay host block every press on web. A comment in the file documents this footgun.
- Added the standard `mobile-web-app-capable` meta tag alongside the apple-prefixed one Chrome warns about (`public/index.html`).

## How to test

1. `bun run web`, open http://localhost:8081.
2. Resize the window to ~iPhone size (≈390×664): caption is black, logo/heading shrink, and the music/sound buttons no longer cover the mode switcher. Restore desktop size: full-size layout unchanged.
3. Console should show none of the three deprecation warnings (hard refresh for the meta-tag one).
4. Start a game: card score numbers still have the same hard 1px shadow; open the in-game menu dialog — it renders and its buttons are clickable (overlay host regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)