### PR TITLE
fix: stop the board jumping when a pinch-zoom is released

### DIFF
--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -81,6 +81,12 @@ const Table = forwardRef<TableHandle, TableProps>(({ style, ...rest }, ref) => {
   const savedScale = useSharedValue(1);
   const originX = useSharedValue(0);
   const originY = useSharedValue(0);
+  // The pinch focal is the centroid of the current touches, so it snaps when a
+  // finger lands or lifts mid-gesture (iOS keeps the pinch active on the last
+  // finger, and trackpad pinches report zero touches). Tracking the pointer
+  // count lets the origin re-anchor at each transition instead of jumping.
+  const pinchPointers = useSharedValue(0);
+  const pinchActive = useSharedValue(false);
 
   // Preserve the imperative API the rest of the app relies on: onCardDrop reads
   // _previousLeft/_previousTop/_previousScale to map a dropped card to a cell,
@@ -115,6 +121,12 @@ const Table = forwardRef<TableHandle, TableProps>(({ style, ...rest }, ref) => {
       savedY.value = translateY.value;
     })
     .onUpdate((e) => {
+      // On iOS the pan stays active underneath a pinch (UIKit ignores touches
+      // beyond maxPointers instead of failing the recognizer), so its
+      // snapshot-based writes must yield while the pinch owns the transform.
+      if (pinchActive.value) {
+        return;
+      }
       const next = clampToBoundaries(
         savedX.value + e.translationX,
         savedY.value + e.translationY,
@@ -132,11 +144,22 @@ const Table = forwardRef<TableHandle, TableProps>(({ style, ...rest }, ref) => {
 
   const pinch = Gesture.Pinch()
     .onStart((e) => {
+      pinchActive.value = true;
+      pinchPointers.value = e.numberOfPointers;
       savedScale.value = scale.value;
       originX.value = (e.focalX - translateX.value) / scale.value;
       originY.value = (e.focalY - translateY.value) / scale.value;
     })
     .onUpdate((e) => {
+      if (e.numberOfPointers !== pinchPointers.value) {
+        // Re-anchor so this frame leaves the transform unchanged. e.scale
+        // keeps accumulating across the pointer change, so fold it into the
+        // baseline rather than resetting it.
+        pinchPointers.value = e.numberOfPointers;
+        savedScale.value = scale.value / e.scale;
+        originX.value = (e.focalX - translateX.value) / scale.value;
+        originY.value = (e.focalY - translateY.value) / scale.value;
+      }
       const nextScale = clampValue(
         savedScale.value * e.scale,
         MIN_ZOOM,
@@ -158,6 +181,11 @@ const Table = forwardRef<TableHandle, TableProps>(({ style, ...rest }, ref) => {
       savedScale.value = scale.value;
       savedX.value = translateX.value;
       savedY.value = translateY.value;
+    })
+    // onFinalize also runs when the gesture fails or is cancelled, so the pan
+    // is never left permanently suppressed.
+    .onFinalize(() => {
+      pinchActive.value = false;
     });
 
   const gesture = Gesture.Simultaneous(pan, pinch);


### PR DESCRIPTION
## Problem

When pinch-zooming the board, the view jumps/repositions at the moment fingers lift, instead of staying exactly where it was during the pinch.

## Root causes

Two mechanisms, both verified against the react-native-gesture-handler 2.31.1 sources:

1. **Focal snap on finger lift (primary, iOS).** The pinch focal is the centroid of the current touches, recomputed every event. On iOS, `UIPinchGestureRecognizer` stays active when one of two fingers lifts, so `onUpdate` keeps firing with the focal snapped from the two-finger midpoint to the remaining finger (~half the finger separation). The focal-pinning math `translate = focal − origin·scale` then applied that snap as a one-frame translate jump. Even a "simultaneous" lift delivers the two touch-ends milliseconds apart.
2. **Pan running underneath the pinch (secondary, iOS).** `pan.maxPointers(1)` maps to UIKit's `maximumNumberOfTouches`, which *ignores* extra touches rather than failing an active recognizer — so a pan that activated before the second finger landed stays active through the whole pinch, writing from a stale snapshot on every finger-1 move. It usually loses the per-frame write race to the pinch but can win the last write at release.

## Fix (`src/Table/index.tsx` only, +28 lines)

- **Re-anchor the pinch origin whenever the pointer count changes.** The re-anchor frame recomputes `origin` from the current focal/translate/scale and folds the accumulated `e.scale` into the baseline, so that frame leaves the transform bit-identical — an exact no-op regardless of how the focal jumped. A simple `numberOfPointers < 2` guard was rejected: iPad trackpad pinches report **zero** touches on every event, so it would silently kill trackpad zoom.
- **Suppress pan writes while a pinch is active** via a `pinchActive` shared value, cleared in `onFinalize` (which also runs on fail/cancel, so the pan can never get stuck suppressed).

Side benefit: after lifting one finger mid-pinch, the remaining finger now smoothly pans via focal tracking (Google-Maps-style) instead of jolting the board.

No changes to `TableHandle` semantics — the getters still read the live shared values; the fix only prevents spurious writes, so `onCardDrop` cell mapping if anything gets slightly more accurate (the resting translate no longer includes the one-frame focal-jump error).

## Manual test steps

**Real iOS device (the true repro):**
- Pinch, then lift ONE finger while holding the other still → board must not move; dragging the remaining finger should smoothly pan.
- Pinch and lift both fingers together → no jump.
- One-finger drag, add a second finger mid-drag (becomes a pinch), release → exercises the pan-behind-pinch guard.

**iOS Simulator:** Option+drag lifts both synthetic touches symmetrically, so use it for regression (focal-pinned zoom, edge clamping, min/max zoom). To force a 2→1 transition: while pinching with Option held, release the Option key with the mouse button still down and watch for a jump.

**Regression:** at several zoom levels (incl. clamped min/max and board corners), pinch, release, then drag a card and confirm it lands in the aimed cell; trigger menu → scroll-to-center after a pinch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)