### PR TITLE
design: tighten animal icon spacing on the player-count buttons

### DIFF
--- a/src/PlayerButton/index.tsx
+++ b/src/PlayerButton/index.tsx
@@ -23,19 +23,19 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
       // overlap slightly (negative margin) to read as a tight cluster.
       switch (number) {
         case 1: {
-          return { size: 72, margin: -3 };
+          return { size: 72, margin: -1 };
         }
         case 2: {
-          return { size: 44, margin: -3 };
+          return { size: 44, margin: -1 };
         }
         // The fixed rowWidth keeps the wrap at two icons per row — the
-        // overlapped footprints (30px each) would otherwise fit three across.
+        // overlapped footprints (34px each) would otherwise fit three across.
         case 3:
         case 4: {
-          return { size: 36, margin: -3, rowWidth: 66 };
+          return { size: 36, margin: -1, rowWidth: 70 };
         }
         default: {
-          return { size: 64, margin: -3 };
+          return { size: 64, margin: -1 };
         }
       }
     },

--- a/src/PlayerButton/index.tsx
+++ b/src/PlayerButton/index.tsx
@@ -17,38 +17,25 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
     .fill(undefined)
     .map((n, i) => Animals[playerConfig[i]["animal"]]);
 
-  const getIconSize = useCallback(
-    function () {
+  const getIconLayout = useCallback(
+    function (): { size: number; margin: number; rowWidth?: number } {
       switch (number) {
         case 1: {
-          return {
-            width: 72,
-            height: 72,
-          };
+          return { size: 72, margin: 4 };
         }
         case 2: {
-          return {
-            width: 44,
-            height: 44,
-          };
+          return { size: 44, margin: 4 };
         }
-        case 3: {
-          return {
-            width: 36,
-            height: 36,
-          };
-        }
+        // The animal art carries its own padding, so 3- and 4-player
+        // icons overlap slightly to read as a tight cluster. The fixed
+        // rowWidth keeps the wrap at two icons per row — the overlapped
+        // footprints (36px each) would otherwise fit three across.
+        case 3:
         case 4: {
-          return {
-            width: 36,
-            height: 36,
-          };
+          return { size: 42, margin: -3, rowWidth: 78 };
         }
         default: {
-          return {
-            width: 64,
-            height: 64,
-          };
+          return { size: 64, margin: 4 };
         }
       }
     },
@@ -77,6 +64,8 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
     [number]
   );
 
+  const { size, margin, rowWidth } = getIconLayout();
+
   return (
     <TouchableOpacity onPress={onPress} activeOpacity={0.8}>
       <View
@@ -91,6 +80,7 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
         <View style={styles.tagInner}>
           <View
             style={{
+              width: rowWidth,
               flexDirection: "row",
               flexWrap: "wrap",
               justifyContent: "center",
@@ -98,7 +88,7 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
             }}
           >
             {PlayerIcons.map((Icon, i) => (
-              <Icon key={i} {...getIconSize()} style={{ margin: 4 }} />
+              <Icon key={i} width={size} height={size} style={{ margin }} />
             ))}
           </View>
         </View>

--- a/src/PlayerButton/index.tsx
+++ b/src/PlayerButton/index.tsx
@@ -19,23 +19,21 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
 
   const getIconLayout = useCallback(
     function (): { size: number; margin: number; rowWidth?: number } {
-      // The animal art carries its own padding, so the icon boxes sit
-      // edge-to-edge and still read as a tight cluster.
       switch (number) {
         case 1: {
-          return { size: 72, margin: 0 };
+          return { size: 72, margin: 2 };
         }
         case 2: {
-          return { size: 44, margin: 0 };
+          return { size: 44, margin: 2 };
         }
         // The fixed rowWidth keeps the wrap at two icons per row —
-        // three gapless 36px icons would otherwise fit across.
+        // three 36px icons with 2px margins would otherwise fit across.
         case 3:
         case 4: {
-          return { size: 36, margin: 0, rowWidth: 72 };
+          return { size: 36, margin: 2, rowWidth: 80 };
         }
         default: {
-          return { size: 64, margin: 0 };
+          return { size: 64, margin: 2 };
         }
       }
     },

--- a/src/PlayerButton/index.tsx
+++ b/src/PlayerButton/index.tsx
@@ -19,23 +19,23 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
 
   const getIconLayout = useCallback(
     function (): { size: number; margin: number; rowWidth?: number } {
+      // The animal art carries its own padding, so the icon boxes
+      // overlap slightly (negative margin) to read as a tight cluster.
       switch (number) {
         case 1: {
-          return { size: 72, margin: 4 };
+          return { size: 72, margin: -3 };
         }
         case 2: {
-          return { size: 44, margin: 4 };
+          return { size: 44, margin: -3 };
         }
-        // The animal art carries its own padding, so 3- and 4-player
-        // icons overlap slightly to read as a tight cluster. The fixed
-        // rowWidth keeps the wrap at two icons per row — the overlapped
-        // footprints (36px each) would otherwise fit three across.
+        // The fixed rowWidth keeps the wrap at two icons per row — the
+        // overlapped footprints (30px each) would otherwise fit three across.
         case 3:
         case 4: {
-          return { size: 42, margin: -3, rowWidth: 78 };
+          return { size: 36, margin: -3, rowWidth: 66 };
         }
         default: {
-          return { size: 64, margin: 4 };
+          return { size: 64, margin: -3 };
         }
       }
     },

--- a/src/PlayerButton/index.tsx
+++ b/src/PlayerButton/index.tsx
@@ -19,23 +19,23 @@ const PlayerButton = ({ number, onPress, style }: PlayerButtonProps) => {
 
   const getIconLayout = useCallback(
     function (): { size: number; margin: number; rowWidth?: number } {
-      // The animal art carries its own padding, so the icon boxes
-      // overlap slightly (negative margin) to read as a tight cluster.
+      // The animal art carries its own padding, so the icon boxes sit
+      // edge-to-edge and still read as a tight cluster.
       switch (number) {
         case 1: {
-          return { size: 72, margin: -1 };
+          return { size: 72, margin: 0 };
         }
         case 2: {
-          return { size: 44, margin: -1 };
+          return { size: 44, margin: 0 };
         }
-        // The fixed rowWidth keeps the wrap at two icons per row — the
-        // overlapped footprints (34px each) would otherwise fit three across.
+        // The fixed rowWidth keeps the wrap at two icons per row —
+        // three gapless 36px icons would otherwise fit across.
         case 3:
         case 4: {
-          return { size: 36, margin: -1, rowWidth: 70 };
+          return { size: 36, margin: 0, rowWidth: 72 };
         }
         default: {
-          return { size: 64, margin: -1 };
+          return { size: 64, margin: 0 };
         }
       }
     },


### PR DESCRIPTION
## What

On the "How many players?" menu, the animal icons inside each circular button now sit closer together: each icon's margin goes from 4px to 2px (an 8px gap between neighbors is now 4px). The animal art carries its own padding, so the tighter packing still reads cleanly.

Icon sizes are unchanged (72px for 1-player, 44px for 2-player, 36px for 3/4-player).

## How

- `PlayerButton` now computes a per-count icon layout (`size`, `margin`, `rowWidth`) in one place.
- The 3- and 4-player buttons get a fixed 80px row width to force the wrap at two icons per row — with the tighter margins, three 36px icons would otherwise fit on one line.

## Manual test

1. `bun run web` and open localhost:8081 (or launch the iOS app).
2. On the main menu, check all four player-count circles: 1 and 2 players look as before aside from the slightly tighter 2-player pair; 3 and 4 players cluster as 2+1 and 2+2 with a 4px gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)