### PR TITLE
Drag & drop: reliable placement, drop-target highlight, and instant animations

### DIFF
--- a/src/Board/index.tsx
+++ b/src/Board/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 
 import Card from "../Card";
+import type { CardEntrance } from "../Card";
 import type { GameState } from "../Matchimals/game";
 import {
   boardHeight,
@@ -12,15 +13,37 @@ import {
   rows,
 } from "../constants/board";
 
-const Board = ({ G }: { G: GameState }) => {
+export type LastPlacement = CardEntrance & { cell: number };
+
+const Board = ({
+  G,
+  lastPlacement,
+}: {
+  G: GameState;
+  lastPlacement?: LastPlacement | null;
+}) => {
   let cells = [];
   for (let i = 0; i < rows; i++) {
     for (let j = 0; j < columns; j++) {
       const id = columns * i + j;
       const value = G.cells[id];
+      // The most recently placed card slides in from the drag release point;
+      // its cell is elevated so the moving card passes over its neighbors.
+      const isEntering = lastPlacement?.cell === id;
       cells.push(
-        <View key={id} id={`${id}`} style={styles.cell}>
-          {value && <Card card={value} flipped disabled />}
+        <View
+          key={id}
+          id={`${id}`}
+          style={[styles.cell, isEntering && styles.cellEntering]}
+        >
+          {value && (
+            <Card
+              card={value}
+              flipped
+              disabled
+              entrance={isEntering ? lastPlacement : undefined}
+            />
+          )}
         </View>
       );
     }
@@ -41,6 +64,9 @@ const styles = StyleSheet.create({
     height: cardHeight,
     justifyContent: "center",
     alignItems: "center",
+  },
+  cellEntering: {
+    zIndex: 1,
   },
 });
 

--- a/src/Board/index.tsx
+++ b/src/Board/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 
 import Card from "../Card";
-import type { CardEntrance } from "../Card";
 import type { Card as CardType } from "../constants/cards";
 import type { GameState } from "../Matchimals/game";
 import {
@@ -14,55 +13,27 @@ import {
   rows,
 } from "../constants/board";
 
-export type LastPlacement = CardEntrance & { cell: number };
-
-// Memoized so a placement re-renders only the affected cells, not every placed
+// Memoized so a placement re-renders only the affected cell, not every placed
 // card's SVG tree — that full-board render happens synchronously at drop time
-// and would delay the placed card's entrance animation. Unchanged `value`s keep
+// and would delay the drop's visual response. Unchanged `value`s keep
 // reference identity across moves (Immer structural sharing), so the shallow
-// compare bails for the other ~473 cells.
+// compare bails for the other ~474 cells.
 const BoardCell = React.memo(
-  ({
-    id,
-    value,
-    entrance,
-  }: {
-    id: number;
-    value: CardType | null;
-    entrance?: CardEntrance;
-  }) => (
-    <View
-      id={`${id}`}
-      // The most recently placed card slides in from the drag release point;
-      // its cell is elevated so the moving card passes over its neighbors.
-      style={[styles.cell, entrance && styles.cellEntering]}
-    >
-      {value && <Card card={value} flipped disabled entrance={entrance} />}
+  ({ id, value }: { id: number; value: CardType | null }) => (
+    <View id={`${id}`} style={styles.cell}>
+      {value && <Card card={value} flipped disabled />}
     </View>
   )
 );
 
 BoardCell.displayName = "BoardCell";
 
-const Board = ({
-  G,
-  lastPlacement,
-}: {
-  G: GameState;
-  lastPlacement?: LastPlacement | null;
-}) => {
+const Board = ({ G }: { G: GameState }) => {
   let cells = [];
   for (let i = 0; i < rows; i++) {
     for (let j = 0; j < columns; j++) {
       const id = columns * i + j;
-      cells.push(
-        <BoardCell
-          key={id}
-          id={id}
-          value={G.cells[id]}
-          entrance={lastPlacement?.cell === id ? lastPlacement : undefined}
-        />
-      );
+      cells.push(<BoardCell key={id} id={id} value={G.cells[id]} />);
     }
   }
 
@@ -81,9 +52,6 @@ const styles = StyleSheet.create({
     height: cardHeight,
     justifyContent: "center",
     alignItems: "center",
-  },
-  cellEntering: {
-    zIndex: 1,
   },
 });
 

--- a/src/Board/index.tsx
+++ b/src/Board/index.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from "react-native";
 
 import Card from "../Card";
 import type { CardEntrance } from "../Card";
+import type { Card as CardType } from "../constants/cards";
 import type { GameState } from "../Matchimals/game";
 import {
   boardHeight,
@@ -15,6 +16,34 @@ import {
 
 export type LastPlacement = CardEntrance & { cell: number };
 
+// Memoized so a placement re-renders only the affected cells, not every placed
+// card's SVG tree — that full-board render happens synchronously at drop time
+// and would delay the placed card's entrance animation. Unchanged `value`s keep
+// reference identity across moves (Immer structural sharing), so the shallow
+// compare bails for the other ~473 cells.
+const BoardCell = React.memo(
+  ({
+    id,
+    value,
+    entrance,
+  }: {
+    id: number;
+    value: CardType | null;
+    entrance?: CardEntrance;
+  }) => (
+    <View
+      id={`${id}`}
+      // The most recently placed card slides in from the drag release point;
+      // its cell is elevated so the moving card passes over its neighbors.
+      style={[styles.cell, entrance && styles.cellEntering]}
+    >
+      {value && <Card card={value} flipped disabled entrance={entrance} />}
+    </View>
+  )
+);
+
+BoardCell.displayName = "BoardCell";
+
 const Board = ({
   G,
   lastPlacement,
@@ -26,25 +55,13 @@ const Board = ({
   for (let i = 0; i < rows; i++) {
     for (let j = 0; j < columns; j++) {
       const id = columns * i + j;
-      const value = G.cells[id];
-      // The most recently placed card slides in from the drag release point;
-      // its cell is elevated so the moving card passes over its neighbors.
-      const isEntering = lastPlacement?.cell === id;
       cells.push(
-        <View
+        <BoardCell
           key={id}
-          id={`${id}`}
-          style={[styles.cell, isEntering && styles.cellEntering]}
-        >
-          {value && (
-            <Card
-              card={value}
-              flipped
-              disabled
-              entrance={isEntering ? lastPlacement : undefined}
-            />
-          )}
-        </View>
+          id={id}
+          value={G.cells[id]}
+          entrance={lastPlacement?.cell === id ? lastPlacement : undefined}
+        />
       );
     }
   }

--- a/src/Card/CardFront.tsx
+++ b/src/Card/CardFront.tsx
@@ -149,4 +149,6 @@ const styles = StyleSheet.create({
   },
 });
 
-export default CardFront;
+// Memoized: card objects keep reference identity across game-state updates, so
+// re-renders of a parent (Deck, FlyingCard) skip these SVG-heavy subtrees.
+export default React.memo(CardFront);

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -6,6 +6,7 @@ import Reanimated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
+  withSpring,
 } from "react-native-reanimated";
 import type { SharedValue } from "react-native-reanimated";
 
@@ -14,16 +15,35 @@ import type { Card as CardType } from "../constants/cards";
 import CardBack from "./CardBack";
 import CardFront from "./CardFront";
 
+// Snap-back: soft enough for a playful overshoot on the way home to the deck.
+const SNAP_BACK_SPRING = { damping: 15, stiffness: 180 };
+// Fly-to-cell: stiff so the card settles fast — the move only commits once the
+// springs rest, so a long tail would delay the turn.
+const FLY_SPRING = { damping: 22, stiffness: 280 };
+
 export type CardDropPoint = {
   centerX: number;
   centerY: number;
 };
 
+// A legal drop hands back where the card should fly to; the move only commits
+// once the card has visually landed, so the swap to the placed board card is
+// pixel-identical.
+export type DropResult =
+  | {
+      placed: true;
+      // Screen-space center of the target cell and the board's current zoom.
+      cellCenter: { x: number; y: number };
+      boardScale: number;
+      commit: () => void;
+    }
+  | { placed: false };
+
 interface CardProps extends ViewProps {
   card?: CardType;
   disabled?: boolean;
   flipped?: boolean;
-  onCardDrop?: (point: CardDropPoint) => Promise<unknown>;
+  onCardDrop?: (point: CardDropPoint) => DropResult;
   // Written while a drag is in flight so the board can preview the drop target
   // on the UI thread. dragActive only flips true once the drag-start
   // measurement lands, so readers never see a center derived from a stale base.
@@ -44,6 +64,9 @@ const Card = ({
   ...rest
 }: CardProps) => {
   const [dragging, setDragging] = useState(false);
+  // While an end-of-drag animation (snap-back or fly-to-cell) is running the
+  // gesture is disabled, so the card can't be re-grabbed mid-flight.
+  const [settling, setSettling] = useState(false);
   const cardRef = useRef<View>(null);
   const baseMeasured = useRef(false);
 
@@ -59,12 +82,25 @@ const Card = ({
   // can lag the UI-thread transform by a frame or two on Fabric).
   const baseCenterX = useSharedValue(0);
   const baseCenterY = useSharedValue(0);
+  // Counts the fly-to-cell springs still moving; the move commits when the
+  // last one rests.
+  const flyRemaining = useSharedValue(0);
 
-  const reset = useCallback(() => {
-    translateX.value = 0;
-    translateY.value = 0;
+  const finishSnapBack = useCallback(() => {
+    setSettling(false);
     setDragging(false);
-  }, [translateX, translateY]);
+  }, []);
+
+  // Spring home to the deck, keeping the card's elevated zIndex until it has
+  // settled so it doesn't slide underneath other UI on the way back.
+  const snapBack = useCallback(() => {
+    setSettling(true);
+    scale.value = withSpring(1, SNAP_BACK_SPRING);
+    translateY.value = withSpring(0, SNAP_BACK_SPRING);
+    translateX.value = withSpring(0, SNAP_BACK_SPRING, () => {
+      runOnJS(finishSnapBack)();
+    });
+  }, [scale, translateX, translateY, finishSnapBack]);
 
   // Runs on JS at drag start, while the card is still at rest in the deck —
   // measureInWindow is reliable there (the 1.05 pickup scale is center-origin,
@@ -97,20 +133,60 @@ const Card = ({
       // A release before the drag-start measurement resolves (an instant tap)
       // has no trustworthy drop point — treat it as a cancelled drag.
       if (!didDrop || !baseMeasured.current || !onCardDrop) {
-        reset();
+        snapBack();
         return;
       }
       // Shared-value reads from JS are synchronous, and the values are settled
       // once the finger has lifted.
-      onCardDrop({
+      const result = onCardDrop({
         centerX: baseCenterX.value + translateX.value,
         centerY: baseCenterY.value + translateY.value,
-      }).then(reset, reset);
+      });
+      if (!result.placed) {
+        snapBack();
+        return;
+      }
+      // Fly into the cell, scaling from screen size to the board zoom. The
+      // commit waits for ALL three springs to rest: the placed board card must
+      // appear exactly where this one settles or the swap would visibly jump.
+      // Committing unmounts this card (its deck key disappears), completing
+      // the swap.
+      setSettling(true);
+      const { commit } = result;
+      flyRemaining.value = 3;
+      const onSpringRest = () => {
+        "worklet";
+        flyRemaining.value -= 1;
+        if (flyRemaining.value === 0) {
+          runOnJS(commit)();
+        }
+      };
+      scale.value = withSpring(result.boardScale, FLY_SPRING, onSpringRest);
+      translateX.value = withSpring(
+        result.cellCenter.x - baseCenterX.value,
+        FLY_SPRING,
+        onSpringRest
+      );
+      translateY.value = withSpring(
+        result.cellCenter.y - baseCenterY.value,
+        FLY_SPRING,
+        onSpringRest
+      );
     },
-    [onCardDrop, reset, baseCenterX, baseCenterY, translateX, translateY]
+    [
+      onCardDrop,
+      snapBack,
+      baseCenterX,
+      baseCenterY,
+      translateX,
+      translateY,
+      scale,
+      flyRemaining,
+    ]
   );
 
   const gesture = Gesture.Pan()
+    .enabled(!settling)
     .minDistance(0)
     .onStart(() => {
       scale.value = 1.05;
@@ -125,7 +201,8 @@ const Card = ({
       }
     })
     .onFinalize((e, success) => {
-      scale.value = 1;
+      // The scale stays at pickup size here; handleEnd picks the animation
+      // that brings it home (snap-back) or to the board zoom (fly-to-cell).
       if (dragActive) {
         dragActive.value = false;
       }

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import type { ViewProps } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
@@ -16,23 +16,19 @@ import type { Card as CardType } from "../constants/cards";
 import CardBack from "./CardBack";
 import CardFront from "./CardFront";
 
-// How much the card grows when picked up. Placement math depends on it: a
-// placed card's entrance starts at this scale (converted to board coordinates).
+// How much the card grows when picked up. The FlyingCard overlay starts its
+// flight at this scale so it matches the dragged card exactly.
 export const PICKUP_SCALE = 1.05;
 
-const SETTLE_TIMING = { duration: 180, easing: Easing.out(Easing.cubic) };
+// Shared by the snap-back and the FlyingCard's flight into the cell.
+export const SETTLE_TIMING = {
+  duration: 180,
+  easing: Easing.out(Easing.cubic),
+};
 
 export type CardDropPoint = {
   centerX: number;
   centerY: number;
-};
-
-// Where a placed card's entrance animation starts, relative to its cell:
-// offsets in board pixels from the cell center, scale in board units.
-export type CardEntrance = {
-  x: number;
-  y: number;
-  scale: number;
 };
 
 interface CardProps extends ViewProps {
@@ -40,10 +36,9 @@ interface CardProps extends ViewProps {
   disabled?: boolean;
   flipped?: boolean;
   // Returns whether the card was placed. A placement commits the move
-  // immediately (unmounting this deck card) and the placed board card animates
-  // in from the release point, so the next deck card is grabbable right away.
+  // immediately (this deck card hides at once and unmounts on the next deck
+  // render) while the FlyingCard overlay carries the visual into the cell.
   onCardDrop?: (point: CardDropPoint) => boolean;
-  entrance?: CardEntrance;
   // Written while a drag is in flight so the board can preview the drop target
   // on the UI thread. dragActive only flips true once the drag-start
   // measurement lands, so readers never see a center derived from a stale base.
@@ -52,47 +47,11 @@ interface CardProps extends ViewProps {
   dragActive?: SharedValue<boolean>;
 }
 
-// Slides a just-placed card from the drag release point into its cell. The
-// start transform is captured at mount; the swap from the dragged deck card to
-// this one happens in a single React commit, so the first frame renders
-// exactly where the drag ended.
-const EntranceView = ({
-  entrance,
-  style,
-  children,
-  ...rest
-}: ViewProps & { entrance: CardEntrance }) => {
-  const translateX = useSharedValue(entrance.x);
-  const translateY = useSharedValue(entrance.y);
-  const scale = useSharedValue(entrance.scale);
-
-  useEffect(() => {
-    translateX.value = withTiming(0, SETTLE_TIMING);
-    translateY.value = withTiming(0, SETTLE_TIMING);
-    scale.value = withTiming(1, SETTLE_TIMING);
-  }, [translateX, translateY, scale]);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateX: translateX.value },
-      { translateY: translateY.value },
-      { scale: scale.value },
-    ],
-  }));
-
-  return (
-    <Reanimated.View style={[style, animatedStyle]} {...rest}>
-      {children}
-    </Reanimated.View>
-  );
-};
-
 const Card = ({
   card = {} as CardType,
   disabled,
   flipped,
   onCardDrop,
-  entrance,
   dragCenterX,
   dragCenterY,
   dragActive,
@@ -100,8 +59,8 @@ const Card = ({
   ...rest
 }: CardProps) => {
   const [dragging, setDragging] = useState(false);
-  // While the snap-back animation is running the gesture is disabled, so the
-  // card can't be re-grabbed mid-flight.
+  // The gesture is disabled while the snap-back animation runs (no re-grab
+  // mid-flight) and after a placement (the card is hidden, awaiting unmount).
   const [settling, setSettling] = useState(false);
   const cardRef = useRef<View>(null);
   const baseMeasured = useRef(false);
@@ -118,6 +77,10 @@ const Card = ({
   // can lag the UI-thread transform by a frame or two on Fabric).
   const baseCenterX = useSharedValue(0);
   const baseCenterY = useSharedValue(0);
+  // Drops to 0 the instant a placement is decided: the FlyingCard overlay
+  // takes over the visual on the same frame, and this card unmounts whenever
+  // the deferred deck render lands.
+  const placedOpacity = useSharedValue(1);
 
   const finishSnapBack = useCallback(() => {
     setSettling(false);
@@ -175,13 +138,24 @@ const Card = ({
         centerX: baseCenterX.value + translateX.value,
         centerY: baseCenterY.value + translateY.value,
       });
-      // A placement has already committed the move: this card unmounts on the
-      // resulting re-render and the placed board card animates into the cell.
-      if (!placed) {
+      if (placed) {
+        // The FlyingCard overlay appears at this exact position on the same
+        // frame; hide this card so the two never show together.
+        placedOpacity.value = 0;
+        setSettling(true);
+      } else {
         snapBack();
       }
     },
-    [onCardDrop, snapBack, baseCenterX, baseCenterY, translateX, translateY]
+    [
+      onCardDrop,
+      snapBack,
+      baseCenterX,
+      baseCenterY,
+      translateX,
+      translateY,
+      placedOpacity,
+    ]
   );
 
   const gesture = Gesture.Pan()
@@ -209,6 +183,7 @@ const Card = ({
     });
 
   const animatedStyle = useAnimatedStyle(() => ({
+    opacity: placedOpacity.value,
     transform: [
       { translateX: translateX.value },
       { translateY: translateY.value },
@@ -217,17 +192,6 @@ const Card = ({
   }));
 
   if (disabled) {
-    if (entrance) {
-      return (
-        <EntranceView
-          entrance={entrance}
-          style={[styles.root, style]}
-          {...rest}
-        >
-          {!flipped ? <CardBack /> : <CardFront card={card} />}
-        </EntranceView>
-      );
-    }
     return (
       <View style={[styles.root, style]} {...rest}>
         {!flipped ? <CardBack /> : <CardFront card={card} />}

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -7,24 +7,29 @@ import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
 } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
 
 import { cardHeight, cardWidth } from "../constants/board";
 import type { Card as CardType } from "../constants/cards";
 import CardBack from "./CardBack";
 import CardFront from "./CardFront";
 
-export type CardDropMeasurements = {
-  pageX: number;
-  pageY: number;
-  width: number;
-  height: number;
+export type CardDropPoint = {
+  centerX: number;
+  centerY: number;
 };
 
 interface CardProps extends ViewProps {
   card?: CardType;
   disabled?: boolean;
   flipped?: boolean;
-  onCardDrop?: (measurements: CardDropMeasurements) => Promise<unknown>;
+  onCardDrop?: (point: CardDropPoint) => Promise<unknown>;
+  // Written while a drag is in flight so the board can preview the drop target
+  // on the UI thread. dragActive only flips true once the drag-start
+  // measurement lands, so readers never see a center derived from a stale base.
+  dragCenterX?: SharedValue<number>;
+  dragCenterY?: SharedValue<number>;
+  dragActive?: SharedValue<boolean>;
 }
 
 const Card = ({
@@ -32,18 +37,28 @@ const Card = ({
   disabled,
   flipped,
   onCardDrop,
+  dragCenterX,
+  dragCenterY,
+  dragActive,
   style,
   ...rest
 }: CardProps) => {
   const [dragging, setDragging] = useState(false);
   const cardRef = useRef<View>(null);
+  const baseMeasured = useRef(false);
 
   // Drag with translate transforms instead of mutating left/top layout props-
   // layout mutation via setNativeProps is unreliable on Fabric. The gesture math
-  // runs on the UI thread; only the drop measurement hops back to JS.
+  // runs on the UI thread; only the drag-start measurement hops back to JS.
   const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
   const scale = useSharedValue(1);
+  // The card's resting center in window coordinates, measured once at drag
+  // start. The live center is base + translation, so the drop point never
+  // depends on a measurement taken while the card is mid-flight (measureInWindow
+  // can lag the UI-thread transform by a frame or two on Fabric).
+  const baseCenterX = useSharedValue(0);
+  const baseCenterY = useSharedValue(0);
 
   const reset = useCallback(() => {
     translateX.value = 0;
@@ -51,35 +66,69 @@ const Card = ({
     setDragging(false);
   }, [translateX, translateY]);
 
-  // Runs on JS. measureInWindow (getBoundingClientRect on web) reflects the
-  // translate transform; measure() reads offsetTop/Left on web and ignores
-  // transforms, so the dragged position would be lost and the card would always
-  // snap back. On a real drop we resolve the cell, then reset to the deck.
+  // Runs on JS at drag start, while the card is still at rest in the deck —
+  // measureInWindow is reliable there (the 1.05 pickup scale is center-origin,
+  // so the center is unaffected even if it has already applied).
+  const startDrag = useCallback(() => {
+    setDragging(true);
+    baseMeasured.current = false;
+    cardRef.current?.measureInWindow((pageX, pageY, width, height) => {
+      baseCenterX.value = pageX + width / 2;
+      baseCenterY.value = pageY + height / 2;
+      baseMeasured.current = true;
+      if (dragCenterX && dragCenterY && dragActive) {
+        dragCenterX.value = baseCenterX.value + translateX.value;
+        dragCenterY.value = baseCenterY.value + translateY.value;
+        dragActive.value = true;
+      }
+    });
+  }, [
+    baseCenterX,
+    baseCenterY,
+    translateX,
+    translateY,
+    dragCenterX,
+    dragCenterY,
+    dragActive,
+  ]);
+
   const handleEnd = useCallback(
     (didDrop: boolean) => {
-      if (!didDrop || !cardRef.current || !onCardDrop) {
+      // A release before the drag-start measurement resolves (an instant tap)
+      // has no trustworthy drop point — treat it as a cancelled drag.
+      if (!didDrop || !baseMeasured.current || !onCardDrop) {
         reset();
         return;
       }
-      cardRef.current.measureInWindow((pageX, pageY, width, height) => {
-        onCardDrop({ pageX, pageY, width, height }).then(reset, reset);
-      });
+      // Shared-value reads from JS are synchronous, and the values are settled
+      // once the finger has lifted.
+      onCardDrop({
+        centerX: baseCenterX.value + translateX.value,
+        centerY: baseCenterY.value + translateY.value,
+      }).then(reset, reset);
     },
-    [onCardDrop, reset]
+    [onCardDrop, reset, baseCenterX, baseCenterY, translateX, translateY]
   );
 
   const gesture = Gesture.Pan()
     .minDistance(0)
     .onStart(() => {
       scale.value = 1.05;
-      runOnJS(setDragging)(true);
+      runOnJS(startDrag)();
     })
     .onUpdate((e) => {
       translateX.value = e.translationX;
       translateY.value = e.translationY;
+      if (dragCenterX && dragCenterY && dragActive && dragActive.value) {
+        dragCenterX.value = baseCenterX.value + e.translationX;
+        dragCenterY.value = baseCenterY.value + e.translationY;
+      }
     })
     .onFinalize((e, success) => {
       scale.value = 1;
+      if (dragActive) {
+        dragActive.value = false;
+      }
       runOnJS(handleEnd)(success);
     });
 

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import type { ViewProps } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Reanimated, {
+  Easing,
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
-  withSpring,
+  withTiming,
 } from "react-native-reanimated";
 import type { SharedValue } from "react-native-reanimated";
 
@@ -15,35 +16,34 @@ import type { Card as CardType } from "../constants/cards";
 import CardBack from "./CardBack";
 import CardFront from "./CardFront";
 
-// Snap-back: soft enough for a playful overshoot on the way home to the deck.
-const SNAP_BACK_SPRING = { damping: 15, stiffness: 180 };
-// Fly-to-cell: stiff so the card settles fast — the move only commits once the
-// springs rest, so a long tail would delay the turn.
-const FLY_SPRING = { damping: 22, stiffness: 280 };
+// How much the card grows when picked up. Placement math depends on it: a
+// placed card's entrance starts at this scale (converted to board coordinates).
+export const PICKUP_SCALE = 1.05;
+
+const SETTLE_TIMING = { duration: 180, easing: Easing.out(Easing.cubic) };
 
 export type CardDropPoint = {
   centerX: number;
   centerY: number;
 };
 
-// A legal drop hands back where the card should fly to; the move only commits
-// once the card has visually landed, so the swap to the placed board card is
-// pixel-identical.
-export type DropResult =
-  | {
-      placed: true;
-      // Screen-space center of the target cell and the board's current zoom.
-      cellCenter: { x: number; y: number };
-      boardScale: number;
-      commit: () => void;
-    }
-  | { placed: false };
+// Where a placed card's entrance animation starts, relative to its cell:
+// offsets in board pixels from the cell center, scale in board units.
+export type CardEntrance = {
+  x: number;
+  y: number;
+  scale: number;
+};
 
 interface CardProps extends ViewProps {
   card?: CardType;
   disabled?: boolean;
   flipped?: boolean;
-  onCardDrop?: (point: CardDropPoint) => DropResult;
+  // Returns whether the card was placed. A placement commits the move
+  // immediately (unmounting this deck card) and the placed board card animates
+  // in from the release point, so the next deck card is grabbable right away.
+  onCardDrop?: (point: CardDropPoint) => boolean;
+  entrance?: CardEntrance;
   // Written while a drag is in flight so the board can preview the drop target
   // on the UI thread. dragActive only flips true once the drag-start
   // measurement lands, so readers never see a center derived from a stale base.
@@ -52,11 +52,47 @@ interface CardProps extends ViewProps {
   dragActive?: SharedValue<boolean>;
 }
 
+// Slides a just-placed card from the drag release point into its cell. The
+// start transform is captured at mount; the swap from the dragged deck card to
+// this one happens in a single React commit, so the first frame renders
+// exactly where the drag ended.
+const EntranceView = ({
+  entrance,
+  style,
+  children,
+  ...rest
+}: ViewProps & { entrance: CardEntrance }) => {
+  const translateX = useSharedValue(entrance.x);
+  const translateY = useSharedValue(entrance.y);
+  const scale = useSharedValue(entrance.scale);
+
+  useEffect(() => {
+    translateX.value = withTiming(0, SETTLE_TIMING);
+    translateY.value = withTiming(0, SETTLE_TIMING);
+    scale.value = withTiming(1, SETTLE_TIMING);
+  }, [translateX, translateY, scale]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { translateY: translateY.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  return (
+    <Reanimated.View style={[style, animatedStyle]} {...rest}>
+      {children}
+    </Reanimated.View>
+  );
+};
+
 const Card = ({
   card = {} as CardType,
   disabled,
   flipped,
   onCardDrop,
+  entrance,
   dragCenterX,
   dragCenterY,
   dragActive,
@@ -64,8 +100,8 @@ const Card = ({
   ...rest
 }: CardProps) => {
   const [dragging, setDragging] = useState(false);
-  // While an end-of-drag animation (snap-back or fly-to-cell) is running the
-  // gesture is disabled, so the card can't be re-grabbed mid-flight.
+  // While the snap-back animation is running the gesture is disabled, so the
+  // card can't be re-grabbed mid-flight.
   const [settling, setSettling] = useState(false);
   const cardRef = useRef<View>(null);
   const baseMeasured = useRef(false);
@@ -82,29 +118,26 @@ const Card = ({
   // can lag the UI-thread transform by a frame or two on Fabric).
   const baseCenterX = useSharedValue(0);
   const baseCenterY = useSharedValue(0);
-  // Counts the fly-to-cell springs still moving; the move commits when the
-  // last one rests.
-  const flyRemaining = useSharedValue(0);
 
   const finishSnapBack = useCallback(() => {
     setSettling(false);
     setDragging(false);
   }, []);
 
-  // Spring home to the deck, keeping the card's elevated zIndex until it has
+  // Ease home to the deck, keeping the card's elevated zIndex until it has
   // settled so it doesn't slide underneath other UI on the way back.
   const snapBack = useCallback(() => {
     setSettling(true);
-    scale.value = withSpring(1, SNAP_BACK_SPRING);
-    translateY.value = withSpring(0, SNAP_BACK_SPRING);
-    translateX.value = withSpring(0, SNAP_BACK_SPRING, () => {
+    scale.value = withTiming(1, SETTLE_TIMING);
+    translateY.value = withTiming(0, SETTLE_TIMING);
+    translateX.value = withTiming(0, SETTLE_TIMING, () => {
       runOnJS(finishSnapBack)();
     });
   }, [scale, translateX, translateY, finishSnapBack]);
 
   // Runs on JS at drag start, while the card is still at rest in the deck —
-  // measureInWindow is reliable there (the 1.05 pickup scale is center-origin,
-  // so the center is unaffected even if it has already applied).
+  // measureInWindow is reliable there (the pickup scale is center-origin, so
+  // the center is unaffected even if it has already applied).
   const startDrag = useCallback(() => {
     setDragging(true);
     baseMeasured.current = false;
@@ -138,58 +171,24 @@ const Card = ({
       }
       // Shared-value reads from JS are synchronous, and the values are settled
       // once the finger has lifted.
-      const result = onCardDrop({
+      const placed = onCardDrop({
         centerX: baseCenterX.value + translateX.value,
         centerY: baseCenterY.value + translateY.value,
       });
-      if (!result.placed) {
+      // A placement has already committed the move: this card unmounts on the
+      // resulting re-render and the placed board card animates into the cell.
+      if (!placed) {
         snapBack();
-        return;
       }
-      // Fly into the cell, scaling from screen size to the board zoom. The
-      // commit waits for ALL three springs to rest: the placed board card must
-      // appear exactly where this one settles or the swap would visibly jump.
-      // Committing unmounts this card (its deck key disappears), completing
-      // the swap.
-      setSettling(true);
-      const { commit } = result;
-      flyRemaining.value = 3;
-      const onSpringRest = () => {
-        "worklet";
-        flyRemaining.value -= 1;
-        if (flyRemaining.value === 0) {
-          runOnJS(commit)();
-        }
-      };
-      scale.value = withSpring(result.boardScale, FLY_SPRING, onSpringRest);
-      translateX.value = withSpring(
-        result.cellCenter.x - baseCenterX.value,
-        FLY_SPRING,
-        onSpringRest
-      );
-      translateY.value = withSpring(
-        result.cellCenter.y - baseCenterY.value,
-        FLY_SPRING,
-        onSpringRest
-      );
     },
-    [
-      onCardDrop,
-      snapBack,
-      baseCenterX,
-      baseCenterY,
-      translateX,
-      translateY,
-      scale,
-      flyRemaining,
-    ]
+    [onCardDrop, snapBack, baseCenterX, baseCenterY, translateX, translateY]
   );
 
   const gesture = Gesture.Pan()
     .enabled(!settling)
     .minDistance(0)
     .onStart(() => {
-      scale.value = 1.05;
+      scale.value = PICKUP_SCALE;
       runOnJS(startDrag)();
     })
     .onUpdate((e) => {
@@ -201,8 +200,8 @@ const Card = ({
       }
     })
     .onFinalize((e, success) => {
-      // The scale stays at pickup size here; handleEnd picks the animation
-      // that brings it home (snap-back) or to the board zoom (fly-to-cell).
+      // The scale stays at pickup size here; a placement swaps this card for
+      // the board card at the same visual size, and a snap-back animates it.
       if (dragActive) {
         dragActive.value = false;
       }
@@ -218,6 +217,17 @@ const Card = ({
   }));
 
   if (disabled) {
+    if (entrance) {
+      return (
+        <EntranceView
+          entrance={entrance}
+          style={[styles.root, style]}
+          {...rest}
+        >
+          {!flipped ? <CardBack /> : <CardFront card={card} />}
+        </EntranceView>
+      );
+    }
     return (
       <View style={[styles.root, style]} {...rest}>
         {!flipped ? <CardBack /> : <CardFront card={card} />}

--- a/src/CellHighlight/index.tsx
+++ b/src/CellHighlight/index.tsx
@@ -46,12 +46,7 @@ const CellHighlight = ({
     };
   });
 
-  return (
-    <Reanimated.View
-      pointerEvents="none"
-      style={[styles.highlight, animatedStyle]}
-    />
-  );
+  return <Reanimated.View style={[styles.highlight, animatedStyle]} />;
 };
 
 const styles = StyleSheet.create({
@@ -63,6 +58,7 @@ const styles = StyleSheet.create({
     height: cardHeight,
     backgroundColor: "rgba(255, 255, 255, 0.1)",
     borderRadius: 8,
+    pointerEvents: "none",
   },
 });
 

--- a/src/CellHighlight/index.tsx
+++ b/src/CellHighlight/index.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import Reanimated, { useAnimatedStyle } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
+
+import { cardHeight, cardWidth, columns, rows } from "../constants/board";
+
+interface CellHighlightProps {
+  // Live drag position in window coordinates, driven by the dragged Card.
+  dragCenterX: SharedValue<number>;
+  dragCenterY: SharedValue<number>;
+  dragActive: SharedValue<boolean>;
+  // The Table's committed transform, needed to map window coords into board
+  // coords. This component renders inside the transformed board layer, so its
+  // own left/top are in board pixels and it is exactly cell-sized at any zoom.
+  tableX: SharedValue<number>;
+  tableY: SharedValue<number>;
+  tableScale: SharedValue<number>;
+}
+
+// Previews the cell a dragged card would drop into. Everything runs in a
+// single UI-thread worklet — no React re-renders while dragging. This must use
+// the same window→cell math as onCardDrop so the card always lands on the
+// highlighted cell.
+const CellHighlight = ({
+  dragCenterX,
+  dragCenterY,
+  dragActive,
+  tableX,
+  tableY,
+  tableScale,
+}: CellHighlightProps) => {
+  const animatedStyle = useAnimatedStyle(() => {
+    const boardX = (dragCenterX.value - tableX.value) / tableScale.value;
+    const boardY = (dragCenterY.value - tableY.value) / tableScale.value;
+    const col = Math.floor(boardX / cardWidth);
+    const row = Math.floor(boardY / cardHeight);
+    const visible =
+      dragActive.value && col >= 0 && col < columns && row >= 0 && row < rows;
+    return {
+      opacity: visible ? 1 : 0,
+      transform: [
+        { translateX: col * cardWidth },
+        { translateY: row * cardHeight },
+      ],
+    };
+  });
+
+  return (
+    <Reanimated.View
+      pointerEvents="none"
+      style={[styles.highlight, animatedStyle]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  highlight: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: cardWidth,
+    height: cardHeight,
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 8,
+  },
+});
+
+export default CellHighlight;

--- a/src/CellHighlight/index.tsx
+++ b/src/CellHighlight/index.tsx
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     top: 0,
     width: cardWidth,
     height: cardHeight,
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    backgroundColor: "rgba(255, 255, 255, 0.2)",
     borderRadius: 8,
     pointerEvents: "none",
   },

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -4,12 +4,12 @@ import type { ViewProps } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 import Card from "../Card";
-import type { CardDropPoint } from "../Card";
+import type { CardDropPoint, DropResult } from "../Card";
 import type { Card as CardType } from "../constants/cards";
 
 interface DeckProps extends ViewProps {
   cards?: CardType[];
-  onCardDrop?: (point: CardDropPoint) => Promise<unknown>;
+  onCardDrop?: (point: CardDropPoint) => DropResult;
   dragCenterX?: SharedValue<number>;
   dragCenterY?: SharedValue<number>;
   dragActive?: SharedValue<boolean>;

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -4,12 +4,12 @@ import type { ViewProps } from "react-native";
 import type { SharedValue } from "react-native-reanimated";
 
 import Card from "../Card";
-import type { CardDropPoint, DropResult } from "../Card";
+import type { CardDropPoint } from "../Card";
 import type { Card as CardType } from "../constants/cards";
 
 interface DeckProps extends ViewProps {
   cards?: CardType[];
-  onCardDrop?: (point: CardDropPoint) => DropResult;
+  onCardDrop?: (point: CardDropPoint) => boolean;
   dragCenterX?: SharedValue<number>;
   dragCenterY?: SharedValue<number>;
   dragActive?: SharedValue<boolean>;

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -68,4 +68,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Deck;
+// Memoized (with a deferred `cards` value and stable callback/shared-value
+// props from Matchimals) so the urgent placement render skips the whole deck
+// stack — it re-renders a frame later, off the drop's critical frame.
+export default React.memo(Deck);

--- a/src/Deck/index.tsx
+++ b/src/Deck/index.tsx
@@ -1,17 +1,29 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import type { ViewProps } from "react-native";
+import type { SharedValue } from "react-native-reanimated";
 
 import Card from "../Card";
-import type { CardDropMeasurements } from "../Card";
+import type { CardDropPoint } from "../Card";
 import type { Card as CardType } from "../constants/cards";
 
 interface DeckProps extends ViewProps {
   cards?: CardType[];
-  onCardDrop?: (measurements: CardDropMeasurements) => Promise<unknown>;
+  onCardDrop?: (point: CardDropPoint) => Promise<unknown>;
+  dragCenterX?: SharedValue<number>;
+  dragCenterY?: SharedValue<number>;
+  dragActive?: SharedValue<boolean>;
 }
 
-const Deck = ({ cards = [], onCardDrop, style, ...rest }: DeckProps) => (
+const Deck = ({
+  cards = [],
+  onCardDrop,
+  dragCenterX,
+  dragCenterY,
+  dragActive,
+  style,
+  ...rest
+}: DeckProps) => (
   <View style={[styles.root, style]} {...rest}>
     {cards.map((card, i) => {
       let shadow;
@@ -32,6 +44,9 @@ const Deck = ({ cards = [], onCardDrop, style, ...rest }: DeckProps) => (
           key={cards.length - i}
           card={card}
           onCardDrop={onCardDrop}
+          dragCenterX={dragCenterX}
+          dragCenterY={dragCenterY}
+          dragActive={dragActive}
           flipped={i === 0}
           style={{
             position: "absolute",

--- a/src/FlyingCard/index.tsx
+++ b/src/FlyingCard/index.tsx
@@ -1,0 +1,139 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { StyleSheet } from "react-native";
+import Reanimated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+
+import { cardHeight, cardWidth } from "../constants/board";
+import { SETTLE_TIMING } from "../Card";
+import CardFront from "../Card/CardFront";
+import type { Card as CardType } from "../constants/cards";
+
+export interface FlightParams {
+  card: CardType;
+  // Screen-space card centers and scales at the start (drag release) and end
+  // (the target cell) of the flight.
+  fromX: number;
+  fromY: number;
+  fromScale: number;
+  toX: number;
+  toY: number;
+  toScale: number;
+}
+
+export interface FlyingCardHandle {
+  fly: (params: FlightParams) => void;
+  hide: () => void;
+}
+
+interface FlyingCardProps {
+  nextCard?: CardType;
+  // Fires when a flight lands. The owner reveals the placed board card
+  // underneath the (still visible) overlay, then calls hide().
+  onArrived?: () => void;
+}
+
+// The visual response to a successful drop. Pre-mounted with the top deck
+// card's face already rendered, so starting a flight is only shared-value
+// writes — it appears on the next frame no matter how long the placement
+// render takes. It keeps covering the target cell after landing until the
+// owner has mounted the real board card beneath it and calls hide().
+const FlyingCard = forwardRef<FlyingCardHandle, FlyingCardProps>(
+  ({ nextCard, onArrived }, ref) => {
+    // The face is frozen for the duration of a flight: the commit swaps
+    // nextCard to the following deck card mid-flight, and the overlay must
+    // keep showing the card that was just placed.
+    const [flightCard, setFlightCard] = useState<CardType | null>(null);
+
+    const translateX = useSharedValue(0);
+    const translateY = useSharedValue(0);
+    const scale = useSharedValue(1);
+    const opacity = useSharedValue(0);
+
+    // The worklet needs a stable JS target; the ref keeps the latest callback.
+    const onArrivedRef = useRef(onArrived);
+    onArrivedRef.current = onArrived;
+    const notifyArrived = useCallback(() => {
+      onArrivedRef.current?.();
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      fly(params) {
+        // Same object the overlay is already rendering (nextCard), so this
+        // re-render is a memo bail, not an SVG mount.
+        setFlightCard(params.card);
+        translateX.value = params.fromX - cardWidth / 2;
+        translateY.value = params.fromY - cardHeight / 2;
+        scale.value = params.fromScale;
+        opacity.value = 1;
+        translateX.value = withTiming(
+          params.toX - cardWidth / 2,
+          SETTLE_TIMING
+        );
+        translateY.value = withTiming(
+          params.toY - cardHeight / 2,
+          SETTLE_TIMING
+        );
+        scale.value = withTiming(params.toScale, SETTLE_TIMING, (finished) => {
+          // A new flight cancels this one; only a completed landing counts as
+          // an arrival.
+          if (finished) {
+            runOnJS(notifyArrived)();
+          }
+        });
+      },
+      hide() {
+        // A short fade covers any sub-frame gap between the board card's
+        // native mount and this overlay disappearing. The face swaps to
+        // nextCard only once fully invisible.
+        opacity.value = withTiming(0, { duration: 80 }, (finished) => {
+          if (finished) {
+            runOnJS(setFlightCard)(null);
+          }
+        });
+      },
+    }));
+
+    const animatedStyle = useAnimatedStyle(() => ({
+      opacity: opacity.value,
+      transform: [
+        { translateX: translateX.value },
+        { translateY: translateY.value },
+        { scale: scale.value },
+      ],
+    }));
+
+    const card = flightCard ?? nextCard;
+
+    return (
+      <Reanimated.View style={[styles.root, animatedStyle]}>
+        {card && <CardFront card={card} />}
+      </Reanimated.View>
+    );
+  }
+);
+
+FlyingCard.displayName = "FlyingCard";
+
+const styles = StyleSheet.create({
+  root: {
+    position: "absolute",
+    left: 0,
+    top: 0,
+    width: cardWidth,
+    height: cardHeight,
+    zIndex: 9999,
+    pointerEvents: "none",
+  },
+});
+
+export default FlyingCard;

--- a/src/Matchimals/game.ts
+++ b/src/Matchimals/game.ts
@@ -52,7 +52,7 @@ export function getNeighbors(G: GameState, id: number): Neighbors {
   if (bottomIndex < cells.length) {
     bottomCard = cells[bottomIndex];
   }
-  if (rightIndex % columns !== 0 && rightIndex < cells.length - 1) {
+  if (rightIndex % columns !== 0 && rightIndex < cells.length) {
     rightCard = cells[rightIndex];
   }
   if (leftIndex % columns !== columns - 1 && leftIndex >= 0) {

--- a/src/Matchimals/index.tsx
+++ b/src/Matchimals/index.tsx
@@ -6,7 +6,9 @@ import type { BoardProps } from "boardgame.io/dist/types/src/client/react";
 
 import { cardHeight, cardWidth, columns, rows } from "../constants/board";
 import Deck from "../Deck";
-import type { CardDropPoint, DropResult } from "../Card";
+import { PICKUP_SCALE } from "../Card";
+import type { CardDropPoint } from "../Card";
+import type { LastPlacement } from "../Board";
 import Button from "../Button";
 import CircleButton from "../CircleButton";
 import Nameplate from "../Nameplate";
@@ -41,8 +43,14 @@ const Matchimals = ({
   const dragCenterY = useSharedValue(0);
   const dragActive = useSharedValue(false);
 
+  // Where the most recent placement was released, so the placed board card can
+  // animate from the release point into its cell.
+  const [lastPlacement, setLastPlacement] = useState<LastPlacement | null>(
+    null
+  );
+
   const onCardDrop = useCallback(
-    (point: CardDropPoint): DropResult => {
+    (point: CardDropPoint): boolean => {
       // The dragged card stays full screen-size while the board scales, so when
       // zoomed out the card visually covers several cells. The drop point is
       // the card's CENTER so it lands where the player aims regardless of zoom.
@@ -77,23 +85,21 @@ const Matchimals = ({
 
       if (!inBounds || !isLegalMove(G, ctx, targetCell)) {
         music.playSoundEffect3(); // Play mismatched card sound effect
-        return { placed: false };
+        return false;
       }
 
-      return {
-        placed: true,
-        // Screen-space center of the target cell, where the card animates to
-        // before the move commits.
-        cellCenter: {
-          x: tableLeft + (cellsFromLeft + 0.5) * cardWidth * scale,
-          y: tableTop + (cellsFromTop + 0.5) * cardHeight * scale,
-        },
-        boardScale: scale,
-        commit: () => {
-          music.playSoundEffect1(); // Play card drop sound effect
-          moves.placeCard(targetCell);
-        },
-      };
+      music.playSoundEffect1(); // Play card drop sound effect
+      setLastPlacement({
+        cell: targetCell,
+        // The placed card's entrance starts at the release point: offsets in
+        // board pixels from the cell center, and the dragged card's screen-size
+        // pickup scale converted to board units.
+        x: boardLeft - (cellsFromLeft + 0.5) * cardWidth,
+        y: boardTop - (cellsFromTop + 0.5) * cardHeight,
+        scale: PICKUP_SCALE / scale,
+      });
+      moves.placeCard(targetCell);
+      return true;
     },
     [G, ctx, moves, music]
   );
@@ -114,6 +120,7 @@ const Matchimals = ({
           dragCenterX={dragCenterX}
           dragCenterY={dragCenterY}
           dragActive={dragActive}
+          lastPlacement={lastPlacement}
           {...rest}
         />
         <View

--- a/src/Matchimals/index.tsx
+++ b/src/Matchimals/index.tsx
@@ -6,7 +6,7 @@ import type { BoardProps } from "boardgame.io/dist/types/src/client/react";
 
 import { cardHeight, cardWidth, columns, rows } from "../constants/board";
 import Deck from "../Deck";
-import type { CardDropPoint } from "../Card";
+import type { CardDropPoint, DropResult } from "../Card";
 import Button from "../Button";
 import CircleButton from "../CircleButton";
 import Nameplate from "../Nameplate";
@@ -42,7 +42,7 @@ const Matchimals = ({
   const dragActive = useSharedValue(false);
 
   const onCardDrop = useCallback(
-    (point: CardDropPoint) => {
+    (point: CardDropPoint): DropResult => {
       // The dragged card stays full screen-size while the board scales, so when
       // zoomed out the card visually covers several cells. The drop point is
       // the card's CENTER so it lands where the player aims regardless of zoom.
@@ -75,15 +75,25 @@ const Matchimals = ({
       // Calculate the target cell's id
       const targetCell = cellsFromTop * columns + cellsFromLeft;
 
-      return new Promise<void>((resolve) => {
-        if (inBounds && isLegalMove(G, ctx, targetCell)) {
+      if (!inBounds || !isLegalMove(G, ctx, targetCell)) {
+        music.playSoundEffect3(); // Play mismatched card sound effect
+        return { placed: false };
+      }
+
+      return {
+        placed: true,
+        // Screen-space center of the target cell, where the card animates to
+        // before the move commits.
+        cellCenter: {
+          x: tableLeft + (cellsFromLeft + 0.5) * cardWidth * scale,
+          y: tableTop + (cellsFromTop + 0.5) * cardHeight * scale,
+        },
+        boardScale: scale,
+        commit: () => {
           music.playSoundEffect1(); // Play card drop sound effect
           moves.placeCard(targetCell);
-        } else {
-          music.playSoundEffect3(); // Play mismatched card sound effect
-        }
-        resolve();
-      });
+        },
+      };
     },
     [G, ctx, moves, music]
   );

--- a/src/Matchimals/index.tsx
+++ b/src/Matchimals/index.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useRef, useState } from "react";
 import { StatusBar, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useSharedValue } from "react-native-reanimated";
 import type { BoardProps } from "boardgame.io/dist/types/src/client/react";
 
-import { cardHeight, cardWidth, columns } from "../constants/board";
+import { cardHeight, cardWidth, columns, rows } from "../constants/board";
 import Deck from "../Deck";
-import type { CardDropMeasurements } from "../Card";
+import type { CardDropPoint } from "../Card";
 import Button from "../Button";
 import CircleButton from "../CircleButton";
 import Nameplate from "../Nameplate";
@@ -33,15 +34,19 @@ const Matchimals = ({
   const tableRef = useRef<TableHandle>(null);
   const insets = useSafeAreaInsets();
 
-  const onCardDrop = useCallback(
-    (measurements: CardDropMeasurements) => {
-      // The dragged card stays full screen-size while the board scales, so when
-      // zoomed out the card visually covers several cells. Use the card's CENTER
-      // (not its top-left corner) as the drop point so it lands where the player
-      // aims regardless of zoom.
-      const cardCenterLeft = measurements.pageX + measurements.width / 2;
-      const cardCenterTop = measurements.pageY + measurements.height / 2;
+  // Live position of the card being dragged (window coordinates), written by
+  // Card on the UI thread and read by the Table's CellHighlight to preview the
+  // drop target without any JS-thread round trips.
+  const dragCenterX = useSharedValue(0);
+  const dragCenterY = useSharedValue(0);
+  const dragActive = useSharedValue(false);
 
+  const onCardDrop = useCallback(
+    (point: CardDropPoint) => {
+      // The dragged card stays full screen-size while the board scales, so when
+      // zoomed out the card visually covers several cells. The drop point is
+      // the card's CENTER so it lands where the player aims regardless of zoom.
+      //
       // Get the top left corner of the viewport in relation to the entire table
       const table = tableRef.current!;
       const tableLeft = table._previousLeft;
@@ -50,18 +55,28 @@ const Matchimals = ({
 
       // Convert the card center from screen pixels back to board pixels (the
       // board is scaled by `scale` around its top-left origin, so 1 screen px ==
-      // 1/scale board px), then find which cell contains that point.
-      const boardLeft = Math.abs(tableLeft - cardCenterLeft) / scale;
-      const boardTop = Math.abs(tableTop - cardCenterTop) / scale;
+      // 1/scale board px), then find which cell contains that point. This must
+      // stay the same math as CellHighlight's worklet so the card always lands
+      // on the highlighted cell.
+      const boardLeft = (point.centerX - tableLeft) / scale;
+      const boardTop = (point.centerY - tableTop) / scale;
 
       const cellsFromLeft = Math.floor(boardLeft / cardWidth);
       const cellsFromTop = Math.floor(boardTop / cardHeight);
+
+      // A drop outside the board must not wrap into a neighboring row via the
+      // flat cell index.
+      const inBounds =
+        cellsFromLeft >= 0 &&
+        cellsFromLeft < columns &&
+        cellsFromTop >= 0 &&
+        cellsFromTop < rows;
 
       // Calculate the target cell's id
       const targetCell = cellsFromTop * columns + cellsFromLeft;
 
       return new Promise<void>((resolve) => {
-        if (isLegalMove(G, ctx, targetCell)) {
+        if (inBounds && isLegalMove(G, ctx, targetCell)) {
           music.playSoundEffect1(); // Play card drop sound effect
           moves.placeCard(targetCell);
         } else {
@@ -82,7 +97,15 @@ const Matchimals = ({
     <>
       <View style={styles.root}>
         <StatusBar hidden />
-        <Table ref={tableRef} G={G} ctx={ctx} {...rest} />
+        <Table
+          ref={tableRef}
+          G={G}
+          ctx={ctx}
+          dragCenterX={dragCenterX}
+          dragCenterY={dragCenterY}
+          dragActive={dragActive}
+          {...rest}
+        />
         <View
           style={{
             position: "absolute",
@@ -102,6 +125,9 @@ const Matchimals = ({
         <Deck
           cards={G.deck}
           onCardDrop={onCardDrop}
+          dragCenterX={dragCenterX}
+          dragCenterY={dragCenterY}
+          dragActive={dragActive}
           style={{
             position: "absolute",
             bottom: Math.max(insets.bottom + cardHeight, 16 + cardHeight),

--- a/src/Matchimals/index.tsx
+++ b/src/Matchimals/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { StatusBar, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useSharedValue } from "react-native-reanimated";
@@ -8,7 +14,8 @@ import { cardHeight, cardWidth, columns, rows } from "../constants/board";
 import Deck from "../Deck";
 import { PICKUP_SCALE } from "../Card";
 import type { CardDropPoint } from "../Card";
-import type { LastPlacement } from "../Board";
+import FlyingCard from "../FlyingCard";
+import type { FlyingCardHandle } from "../FlyingCard";
 import Button from "../Button";
 import CircleButton from "../CircleButton";
 import Nameplate from "../Nameplate";
@@ -24,17 +31,71 @@ type MatchimalsProps = BoardProps<GameState> & {
   backToMainMenu: () => void;
 };
 
-const Matchimals = ({
-  backToMainMenu,
-  ctx,
-  G,
-  moves,
-  ...rest
-}: MatchimalsProps) => {
+// Memoized so the urgent placement render can skip the nameplates (they take
+// deferred values and catch up a frame later, off the drop's critical frame).
+const Nameplates = React.memo(
+  ({
+    players,
+    currentPlayer,
+  }: {
+    players: GameState["players"];
+    currentPlayer: string;
+  }) => (
+    <>
+      {Object.keys(players).map((playerIndex) => (
+        <Nameplate
+          key={playerIndex}
+          player={playerIndex}
+          players={players}
+          currentPlayer={currentPlayer}
+        />
+      ))}
+    </>
+  )
+);
+
+Nameplates.displayName = "Nameplates";
+
+const Matchimals = ({ backToMainMenu, ctx, G, moves }: MatchimalsProps) => {
   const [showMenu, setShowMenu] = useState(false);
   const music = useMusic();
   const tableRef = useRef<TableHandle>(null);
   const insets = useSafeAreaInsets();
+
+  // A placement commits the game state at release, but nothing may MOUNT while
+  // the FlyingCard overlay is mid-flight: Fabric applies mounts on the main
+  // thread, and a placed card's SVG tree landing mid-animation stalls frames
+  // (visible jank). So the UI renders from a frozen display snapshot during
+  // the flight; when the overlay lands, the snapshot catches up in one render
+  // (board card, deck advance, nameplates) underneath the static overlay,
+  // where a render hitch is invisible, and then the overlay fades.
+  const [frozen, setFrozen] = useState(false);
+  const [display, setDisplay] = useState(() => ({
+    G,
+    currentPlayer: ctx.currentPlayer,
+  }));
+  if (
+    !frozen &&
+    (display.G !== G || display.currentPlayer !== ctx.currentPlayer)
+  ) {
+    // Render-phase sync (React's "adjust state during render" pattern) keeps
+    // the snapshot current whenever it isn't deliberately frozen.
+    setDisplay({ G, currentPlayer: ctx.currentPlayer });
+  }
+
+  const deckStyle = useMemo(
+    () => ({
+      position: "absolute" as const,
+      bottom: Math.max(insets.bottom + cardHeight, 16 + cardHeight),
+      left: Math.max(insets.left, 16),
+    }),
+    [insets.bottom, insets.left]
+  );
+
+  // Kept in a ref so onCardDrop's identity never changes — a fresh callback per
+  // move would defeat the Deck's memoization on the urgent placement render.
+  const dropDeps = useRef({ G, ctx, moves, music });
+  dropDeps.current = { G, ctx, moves, music };
 
   // Live position of the card being dragged (window coordinates), written by
   // Card on the UI thread and read by the Table's CellHighlight to preview the
@@ -43,66 +104,85 @@ const Matchimals = ({
   const dragCenterY = useSharedValue(0);
   const dragActive = useSharedValue(false);
 
-  // Where the most recent placement was released, so the placed board card can
-  // animate from the release point into its cell.
-  const [lastPlacement, setLastPlacement] = useState<LastPlacement | null>(
-    null
-  );
+  // The pre-mounted overlay that carries a placed card from the release point
+  // into its cell, so the drop responds on the next frame regardless of how
+  // long the placement render takes.
+  const flyingCardRef = useRef<FlyingCardHandle>(null);
+  const overlayNeedsHide = useRef(false);
 
-  const onCardDrop = useCallback(
-    (point: CardDropPoint): boolean => {
-      // The dragged card stays full screen-size while the board scales, so when
-      // zoomed out the card visually covers several cells. The drop point is
-      // the card's CENTER so it lands where the player aims regardless of zoom.
-      //
-      // Get the top left corner of the viewport in relation to the entire table
-      const table = tableRef.current!;
-      const tableLeft = table._previousLeft;
-      const tableTop = table._previousTop;
-      const scale = table._previousScale || 1;
+  // The flight landed: reveal the real state (mounting the board card and
+  // advancing the deck under the overlay), then hide the overlay once that
+  // render has committed.
+  const onFlightArrived = useCallback(() => {
+    const { G, ctx } = dropDeps.current;
+    overlayNeedsHide.current = true;
+    setFrozen(false);
+    setDisplay({ G, currentPlayer: ctx.currentPlayer });
+  }, []);
 
-      // Convert the card center from screen pixels back to board pixels (the
-      // board is scaled by `scale` around its top-left origin, so 1 screen px ==
-      // 1/scale board px), then find which cell contains that point. This must
-      // stay the same math as CellHighlight's worklet so the card always lands
-      // on the highlighted cell.
-      const boardLeft = (point.centerX - tableLeft) / scale;
-      const boardTop = (point.centerY - tableTop) / scale;
+  useEffect(() => {
+    if (overlayNeedsHide.current) {
+      overlayNeedsHide.current = false;
+      flyingCardRef.current?.hide();
+    }
+  }, [display]);
 
-      const cellsFromLeft = Math.floor(boardLeft / cardWidth);
-      const cellsFromTop = Math.floor(boardTop / cardHeight);
+  const onCardDrop = useCallback((point: CardDropPoint): boolean => {
+    const { G, ctx, moves, music } = dropDeps.current;
+    // The dragged card stays full screen-size while the board scales, so when
+    // zoomed out the card visually covers several cells. The drop point is
+    // the card's CENTER so it lands where the player aims regardless of zoom.
+    //
+    // Get the top left corner of the viewport in relation to the entire table
+    const table = tableRef.current!;
+    const tableLeft = table._previousLeft;
+    const tableTop = table._previousTop;
+    const scale = table._previousScale || 1;
 
-      // A drop outside the board must not wrap into a neighboring row via the
-      // flat cell index.
-      const inBounds =
-        cellsFromLeft >= 0 &&
-        cellsFromLeft < columns &&
-        cellsFromTop >= 0 &&
-        cellsFromTop < rows;
+    // Convert the card center from screen pixels back to board pixels (the
+    // board is scaled by `scale` around its top-left origin, so 1 screen px ==
+    // 1/scale board px), then find which cell contains that point. This must
+    // stay the same math as CellHighlight's worklet so the card always lands
+    // on the highlighted cell.
+    const boardLeft = (point.centerX - tableLeft) / scale;
+    const boardTop = (point.centerY - tableTop) / scale;
 
-      // Calculate the target cell's id
-      const targetCell = cellsFromTop * columns + cellsFromLeft;
+    const cellsFromLeft = Math.floor(boardLeft / cardWidth);
+    const cellsFromTop = Math.floor(boardTop / cardHeight);
 
-      if (!inBounds || !isLegalMove(G, ctx, targetCell)) {
-        music.playSoundEffect3(); // Play mismatched card sound effect
-        return false;
-      }
+    // A drop outside the board must not wrap into a neighboring row via the
+    // flat cell index.
+    const inBounds =
+      cellsFromLeft >= 0 &&
+      cellsFromLeft < columns &&
+      cellsFromTop >= 0 &&
+      cellsFromTop < rows;
 
-      music.playSoundEffect1(); // Play card drop sound effect
-      setLastPlacement({
-        cell: targetCell,
-        // The placed card's entrance starts at the release point: offsets in
-        // board pixels from the cell center, and the dragged card's screen-size
-        // pickup scale converted to board units.
-        x: boardLeft - (cellsFromLeft + 0.5) * cardWidth,
-        y: boardTop - (cellsFromTop + 0.5) * cardHeight,
-        scale: PICKUP_SCALE / scale,
-      });
-      moves.placeCard(targetCell);
-      return true;
-    },
-    [G, ctx, moves, music]
-  );
+    // Calculate the target cell's id
+    const targetCell = cellsFromTop * columns + cellsFromLeft;
+
+    if (!inBounds || !isLegalMove(G, ctx, targetCell)) {
+      music.playSoundEffect3(); // Play mismatched card sound effect
+      return false;
+    }
+
+    music.playSoundEffect1(); // Play card drop sound effect
+    // The overlay flies the card face from the release point into the cell on
+    // the UI thread; the displayed state stays frozen until it lands, so no
+    // mounts can stall frames mid-flight.
+    flyingCardRef.current?.fly({
+      card: G.deck[0],
+      fromX: point.centerX,
+      fromY: point.centerY,
+      fromScale: PICKUP_SCALE,
+      toX: tableLeft + (cellsFromLeft + 0.5) * cardWidth * scale,
+      toY: tableTop + (cellsFromTop + 0.5) * cardHeight * scale,
+      toScale: scale,
+    });
+    setFrozen(true);
+    moves.placeCard(targetCell);
+    return true;
+  }, []);
 
   const onGamePass = useCallback(() => {
     music.playSoundEffect2(); // Play pass card sound effect
@@ -115,13 +195,10 @@ const Matchimals = ({
         <StatusBar hidden />
         <Table
           ref={tableRef}
-          G={G}
-          ctx={ctx}
+          G={display.G}
           dragCenterX={dragCenterX}
           dragCenterY={dragCenterY}
           dragActive={dragActive}
-          lastPlacement={lastPlacement}
-          {...rest}
         />
         <View
           style={{
@@ -130,26 +207,23 @@ const Matchimals = ({
             left: Math.max(insets.left, 16),
           }}
         >
-          {Object.keys(G.players).map((playerIndex) => (
-            <Nameplate
-              key={playerIndex}
-              player={playerIndex}
-              players={G.players}
-              currentPlayer={ctx.currentPlayer}
-            />
-          ))}
+          <Nameplates
+            players={display.G.players}
+            currentPlayer={display.currentPlayer}
+          />
         </View>
         <Deck
-          cards={G.deck}
+          cards={display.G.deck}
           onCardDrop={onCardDrop}
           dragCenterX={dragCenterX}
           dragCenterY={dragCenterY}
           dragActive={dragActive}
-          style={{
-            position: "absolute",
-            bottom: Math.max(insets.bottom + cardHeight, 16 + cardHeight),
-            left: Math.max(insets.left, 16),
-          }}
+          style={deckStyle}
+        />
+        <FlyingCard
+          ref={flyingCardRef}
+          nextCard={G.deck[0]}
+          onArrived={onFlightArrived}
         />
         <Button
           onPress={onGamePass}

--- a/src/Music/index.tsx
+++ b/src/Music/index.tsx
@@ -121,8 +121,10 @@ export const MusicProvider = ({ children }: { children: React.ReactNode }) => {
     if (!soundEffectsEnabled) {
       return;
     }
-    player.seekTo(0);
-    player.play();
+    // seekTo is async: after a clip finishes the player sits at the end, and a
+    // play() issued before the rewind lands is silently swallowed. Wait for
+    // the seek so back-to-back triggers play every time.
+    player.seekTo(0).then(() => player.play());
   };
 
   return (

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -15,9 +15,7 @@ import type { SharedValue } from "react-native-reanimated";
 import WoodBackground from "./wood-background.jpg";
 import { boardHeight, boardWidth } from "../constants/board";
 import Board from "../Board";
-import type { LastPlacement } from "../Board";
 import CellHighlight from "../CellHighlight";
-import type { Ctx } from "boardgame.io";
 import type { GameState } from "../Matchimals/game";
 
 // The imperative API the rest of the app relies on: onCardDrop reads the
@@ -30,14 +28,9 @@ export interface TableHandle {
   scrollToCenter: () => void;
 }
 
-// The rest of the boardgame.io board props spread in by Matchimals ride along
-// via the JSX spread and are passed through to Board untouched.
 interface TableProps {
   style?: { left?: number; top?: number };
   G: GameState;
-  ctx?: Ctx;
-  // Rides along via the JSX spread to Board, which animates the placed card.
-  lastPlacement?: LastPlacement | null;
   // Live drag state from the Deck's top card, previewed by CellHighlight.
   dragCenterX: SharedValue<number>;
   dragCenterY: SharedValue<number>;
@@ -74,7 +67,7 @@ const clampToBoundaries = (
 };
 
 const Table = forwardRef<TableHandle, TableProps>(
-  ({ style, dragCenterX, dragCenterY, dragActive, ...rest }, ref) => {
+  ({ style, dragCenterX, dragCenterY, dragActive, G }, ref) => {
     const { width, height } = useWindowDimensions();
 
     const centeredLeft = (style && style.left) || -((boardWidth - width) / 2);
@@ -217,7 +210,7 @@ const Table = forwardRef<TableHandle, TableProps>(
               source={WoodBackground}
               style={styles.board}
             >
-              <Board {...rest} />
+              <Board G={G} />
               <CellHighlight
                 dragCenterX={dragCenterX}
                 dragCenterY={dragCenterY}

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -15,6 +15,7 @@ import type { SharedValue } from "react-native-reanimated";
 import WoodBackground from "./wood-background.jpg";
 import { boardHeight, boardWidth } from "../constants/board";
 import Board from "../Board";
+import type { LastPlacement } from "../Board";
 import CellHighlight from "../CellHighlight";
 import type { Ctx } from "boardgame.io";
 import type { GameState } from "../Matchimals/game";
@@ -35,6 +36,8 @@ interface TableProps {
   style?: { left?: number; top?: number };
   G: GameState;
   ctx?: Ctx;
+  // Rides along via the JSX spread to Board, which animates the placed card.
+  lastPlacement?: LastPlacement | null;
   // Live drag state from the Deck's top card, previewed by CellHighlight.
   dragCenterX: SharedValue<number>;
   dragCenterY: SharedValue<number>;

--- a/src/Table/index.tsx
+++ b/src/Table/index.tsx
@@ -10,10 +10,12 @@ import Reanimated, {
   useAnimatedStyle,
   useSharedValue,
 } from "react-native-reanimated";
+import type { SharedValue } from "react-native-reanimated";
 
 import WoodBackground from "./wood-background.jpg";
 import { boardHeight, boardWidth } from "../constants/board";
 import Board from "../Board";
+import CellHighlight from "../CellHighlight";
 import type { Ctx } from "boardgame.io";
 import type { GameState } from "../Matchimals/game";
 
@@ -33,6 +35,10 @@ interface TableProps {
   style?: { left?: number; top?: number };
   G: GameState;
   ctx?: Ctx;
+  // Live drag state from the Deck's top card, previewed by CellHighlight.
+  dragCenterX: SharedValue<number>;
+  dragCenterY: SharedValue<number>;
+  dragActive: SharedValue<boolean>;
 }
 
 // MIN_ZOOM stays high enough that the scaled board is always larger than the
@@ -64,156 +70,166 @@ const clampToBoundaries = (
   };
 };
 
-const Table = forwardRef<TableHandle, TableProps>(({ style, ...rest }, ref) => {
-  const { width, height } = useWindowDimensions();
+const Table = forwardRef<TableHandle, TableProps>(
+  ({ style, dragCenterX, dragCenterY, dragActive, ...rest }, ref) => {
+    const { width, height } = useWindowDimensions();
 
-  const centeredLeft = (style && style.left) || -((boardWidth - width) / 2);
-  const centeredTop = (style && style.top) || -((boardHeight - height) / 2);
+    const centeredLeft = (style && style.left) || -((boardWidth - width) / 2);
+    const centeredTop = (style && style.top) || -((boardHeight - height) / 2);
 
-  // The committed (settled) transform. `saved*` snapshot it at the start of each
-  // gesture so adding/lifting a finger never causes a jump; `origin*` is the
-  // board point under the pinch focal, kept pinned to the focal as it scales.
-  const translateX = useSharedValue(centeredLeft);
-  const translateY = useSharedValue(centeredTop);
-  const scale = useSharedValue(1);
-  const savedX = useSharedValue(centeredLeft);
-  const savedY = useSharedValue(centeredTop);
-  const savedScale = useSharedValue(1);
-  const originX = useSharedValue(0);
-  const originY = useSharedValue(0);
-  // The pinch focal is the centroid of the current touches, so it snaps when a
-  // finger lands or lifts mid-gesture (iOS keeps the pinch active on the last
-  // finger, and trackpad pinches report zero touches). Tracking the pointer
-  // count lets the origin re-anchor at each transition instead of jumping.
-  const pinchPointers = useSharedValue(0);
-  const pinchActive = useSharedValue(false);
+    // The committed (settled) transform. `saved*` snapshot it at the start of each
+    // gesture so adding/lifting a finger never causes a jump; `origin*` is the
+    // board point under the pinch focal, kept pinned to the focal as it scales.
+    const translateX = useSharedValue(centeredLeft);
+    const translateY = useSharedValue(centeredTop);
+    const scale = useSharedValue(1);
+    const savedX = useSharedValue(centeredLeft);
+    const savedY = useSharedValue(centeredTop);
+    const savedScale = useSharedValue(1);
+    const originX = useSharedValue(0);
+    const originY = useSharedValue(0);
+    // The pinch focal is the centroid of the current touches, so it snaps when a
+    // finger lands or lifts mid-gesture (iOS keeps the pinch active on the last
+    // finger, and trackpad pinches report zero touches). Tracking the pointer
+    // count lets the origin re-anchor at each transition instead of jumping.
+    const pinchPointers = useSharedValue(0);
+    const pinchActive = useSharedValue(false);
 
-  // Preserve the imperative API the rest of the app relies on: onCardDrop reads
-  // _previousLeft/_previousTop/_previousScale to map a dropped card to a cell,
-  // and Menu calls scrollToCenter().
-  useImperativeHandle(ref, () => ({
-    get _previousLeft() {
-      return translateX.value;
-    },
-    get _previousTop() {
-      return translateY.value;
-    },
-    get _previousScale() {
-      return scale.value;
-    },
-    scrollToCenter() {
-      translateX.value = centeredLeft;
-      translateY.value = centeredTop;
-      scale.value = 1;
-      savedX.value = centeredLeft;
-      savedY.value = centeredTop;
-      savedScale.value = 1;
-    },
-  }));
+    // Preserve the imperative API the rest of the app relies on: onCardDrop reads
+    // _previousLeft/_previousTop/_previousScale to map a dropped card to a cell,
+    // and Menu calls scrollToCenter().
+    useImperativeHandle(ref, () => ({
+      get _previousLeft() {
+        return translateX.value;
+      },
+      get _previousTop() {
+        return translateY.value;
+      },
+      get _previousScale() {
+        return scale.value;
+      },
+      scrollToCenter() {
+        translateX.value = centeredLeft;
+        translateY.value = centeredTop;
+        scale.value = 1;
+        savedX.value = centeredLeft;
+        savedY.value = centeredTop;
+        savedScale.value = 1;
+      },
+    }));
 
-  // One finger pans (maxPointers(1) hands off to the pinch as soon as a second
-  // finger lands). Two fingers pinch-zoom toward the focal point, which also
-  // pans as the fingers slide.
-  const pan = Gesture.Pan()
-    .maxPointers(1)
-    .onStart(() => {
-      savedX.value = translateX.value;
-      savedY.value = translateY.value;
-    })
-    .onUpdate((e) => {
-      // On iOS the pan stays active underneath a pinch (UIKit ignores touches
-      // beyond maxPointers instead of failing the recognizer), so its
-      // snapshot-based writes must yield while the pinch owns the transform.
-      if (pinchActive.value) {
-        return;
-      }
-      const next = clampToBoundaries(
-        savedX.value + e.translationX,
-        savedY.value + e.translationY,
-        scale.value,
-        width,
-        height
-      );
-      translateX.value = next.left;
-      translateY.value = next.top;
-    })
-    .onEnd(() => {
-      savedX.value = translateX.value;
-      savedY.value = translateY.value;
-    });
+    // One finger pans (maxPointers(1) hands off to the pinch as soon as a second
+    // finger lands). Two fingers pinch-zoom toward the focal point, which also
+    // pans as the fingers slide.
+    const pan = Gesture.Pan()
+      .maxPointers(1)
+      .onStart(() => {
+        savedX.value = translateX.value;
+        savedY.value = translateY.value;
+      })
+      .onUpdate((e) => {
+        // On iOS the pan stays active underneath a pinch (UIKit ignores touches
+        // beyond maxPointers instead of failing the recognizer), so its
+        // snapshot-based writes must yield while the pinch owns the transform.
+        if (pinchActive.value) {
+          return;
+        }
+        const next = clampToBoundaries(
+          savedX.value + e.translationX,
+          savedY.value + e.translationY,
+          scale.value,
+          width,
+          height
+        );
+        translateX.value = next.left;
+        translateY.value = next.top;
+      })
+      .onEnd(() => {
+        savedX.value = translateX.value;
+        savedY.value = translateY.value;
+      });
 
-  const pinch = Gesture.Pinch()
-    .onStart((e) => {
-      pinchActive.value = true;
-      pinchPointers.value = e.numberOfPointers;
-      savedScale.value = scale.value;
-      originX.value = (e.focalX - translateX.value) / scale.value;
-      originY.value = (e.focalY - translateY.value) / scale.value;
-    })
-    .onUpdate((e) => {
-      if (e.numberOfPointers !== pinchPointers.value) {
-        // Re-anchor so this frame leaves the transform unchanged. e.scale
-        // keeps accumulating across the pointer change, so fold it into the
-        // baseline rather than resetting it.
+    const pinch = Gesture.Pinch()
+      .onStart((e) => {
+        pinchActive.value = true;
         pinchPointers.value = e.numberOfPointers;
-        savedScale.value = scale.value / e.scale;
+        savedScale.value = scale.value;
         originX.value = (e.focalX - translateX.value) / scale.value;
         originY.value = (e.focalY - translateY.value) / scale.value;
-      }
-      const nextScale = clampValue(
-        savedScale.value * e.scale,
-        MIN_ZOOM,
-        MAX_ZOOM
-      );
-      // Keep the board point captured at onStart pinned under the live focal.
-      const next = clampToBoundaries(
-        e.focalX - originX.value * nextScale,
-        e.focalY - originY.value * nextScale,
-        nextScale,
-        width,
-        height
-      );
-      translateX.value = next.left;
-      translateY.value = next.top;
-      scale.value = nextScale;
-    })
-    .onEnd(() => {
-      savedScale.value = scale.value;
-      savedX.value = translateX.value;
-      savedY.value = translateY.value;
-    })
-    // onFinalize also runs when the gesture fails or is cancelled, so the pan
-    // is never left permanently suppressed.
-    .onFinalize(() => {
-      pinchActive.value = false;
-    });
+      })
+      .onUpdate((e) => {
+        if (e.numberOfPointers !== pinchPointers.value) {
+          // Re-anchor so this frame leaves the transform unchanged. e.scale
+          // keeps accumulating across the pointer change, so fold it into the
+          // baseline rather than resetting it.
+          pinchPointers.value = e.numberOfPointers;
+          savedScale.value = scale.value / e.scale;
+          originX.value = (e.focalX - translateX.value) / scale.value;
+          originY.value = (e.focalY - translateY.value) / scale.value;
+        }
+        const nextScale = clampValue(
+          savedScale.value * e.scale,
+          MIN_ZOOM,
+          MAX_ZOOM
+        );
+        // Keep the board point captured at onStart pinned under the live focal.
+        const next = clampToBoundaries(
+          e.focalX - originX.value * nextScale,
+          e.focalY - originY.value * nextScale,
+          nextScale,
+          width,
+          height
+        );
+        translateX.value = next.left;
+        translateY.value = next.top;
+        scale.value = nextScale;
+      })
+      .onEnd(() => {
+        savedScale.value = scale.value;
+        savedX.value = translateX.value;
+        savedY.value = translateY.value;
+      })
+      // onFinalize also runs when the gesture fails or is cancelled, so the pan
+      // is never left permanently suppressed.
+      .onFinalize(() => {
+        pinchActive.value = false;
+      });
 
-  const gesture = Gesture.Simultaneous(pan, pinch);
+    const gesture = Gesture.Simultaneous(pan, pinch);
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      { translateX: translateX.value },
-      { translateY: translateY.value },
-      { scale: scale.value },
-    ],
-  }));
+    const animatedStyle = useAnimatedStyle(() => ({
+      transform: [
+        { translateX: translateX.value },
+        { translateY: translateY.value },
+        { scale: scale.value },
+      ],
+    }));
 
-  return (
-    <GestureDetector gesture={gesture}>
-      <View style={styles.viewport} collapsable={false}>
-        <Reanimated.View style={[styles.board, animatedStyle]}>
-          <ImageBackground
-            resizeMode="repeat"
-            source={WoodBackground}
-            style={styles.board}
-          >
-            <Board {...rest} />
-          </ImageBackground>
-        </Reanimated.View>
-      </View>
-    </GestureDetector>
-  );
-});
+    return (
+      <GestureDetector gesture={gesture}>
+        <View style={styles.viewport} collapsable={false}>
+          <Reanimated.View style={[styles.board, animatedStyle]}>
+            <ImageBackground
+              resizeMode="repeat"
+              source={WoodBackground}
+              style={styles.board}
+            >
+              <Board {...rest} />
+              <CellHighlight
+                dragCenterX={dragCenterX}
+                dragCenterY={dragCenterY}
+                dragActive={dragActive}
+                tableX={translateX}
+                tableY={translateY}
+                tableScale={scale}
+              />
+            </ImageBackground>
+          </Reanimated.View>
+        </View>
+      </GestureDetector>
+    );
+  }
+);
 
 Table.displayName = "Table";
 


### PR DESCRIPTION
## Summary

This branch fixes the intermittent "dropped it aligned but it didn't connect" bug and rebuilds the drag-and-drop feel around it: a drop-target highlight while dragging, instant snap-back and fly-to-cell animations, and a rendering architecture that keeps the response frame-perfect regardless of render cost.

### Fixes

- **Wrong-cell drops (~1 in 20).** The drop point was measured with `measureInWindow` *after* release, which can lag the UI-thread drag transform by a frame or two on Fabric — releasing while still moving resolved to a neighboring cell. The drop point is now the card's resting center (measured once at drag start, while measurement is reliable) plus the final gesture translation, so there is nothing to go stale.
- **Swallowed sound effects.** `expo-audio`'s `seekTo` is async and a finished player rests at the clip's end, so `play()` issued before the rewind landed was silently dropped on every other trigger. Playback now waits for the seek.
- **`getNeighbors` off-by-one** that excluded the bottom-right corner cell from right-neighbor checks.

### UX

- **Drop-target highlight**: while dragging, the cell the card would land in gets a neutral `rgba(255,255,255,0.2)` rounded fill. Computed entirely on the UI thread from shared values (card drag position + table transform) with the exact same window→cell math as the drop handler, so the highlighted cell is always the landing cell. Zero React re-renders while dragging.
- **Snap-back**: an illegal/cancelled drag eases back to the deck (180ms cubic ease-out), keeping its elevated zIndex until it settles.
- **Placement flight**: a legal drop flies the card face from the release point into the cell, scaling to the current board zoom.

### Architecture (why placement feels instant)

- The move commits at release — sound, rules, and turn advance are never delayed.
- The visual response is a pre-mounted **FlyingCard** overlay whose face (the top deck card) is already rendered: starting the flight is only Reanimated shared-value writes, so it responds on the next frame no matter what React is doing.
- The **displayed** game state freezes during the 180ms flight: Fabric applies mounts on the main thread, and mounting the placed card's SVG tree mid-animation stalls frames. The reveal (board card, deck advance, nameplates) happens in one render underneath the static, pixel-aligned overlay after landing, then the overlay fades over 80ms.
- Board cells are memoized (`BoardCell`), leaning on Immer's structural sharing, so a placement re-renders one cell instead of all 475 (each placed card is an SVG-heavy subtree); `CardFront` and `Deck` are memoized similarly.

## Manual testing

1. `bun install && bun run web` (or `bun run ios`)
2. Drag cards near cell boundaries and drop while still moving ("flick" drops) — the card should always land on the highlighted cell.
3. Drop with intentional misses — the card should ease back to the deck over other UI, with the mismatch sound at release.
4. Place cards rapidly back-to-back — the drop sound should play every time, the flight should stay smooth the whole way (no mid-flight hitch), and the next card should be ready by the time you reach for it.
5. Repeat at min/max pinch-zoom (0.75/1.5) and after panning; the landing swap to the placed board card should be invisible.
6. Play a full game — pass, scoring, and the victory screen are unaffected (they use the real game state, not the display snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)